### PR TITLE
Improved release

### DIFF
--- a/a2p_dependencies.py
+++ b/a2p_dependencies.py
@@ -225,7 +225,9 @@ class Dependency():
             return
 
         self.Enabled = True
-        self.foreignDependency.Enabled = True
+        self.Done = False
+        self.foreignDependency.Enabled = self.Enabled
+        self.foreignDependency.Done = self.Done
         DebugMsg(
             A2P_DEBUG_2,
             "{} - enabled\n".format(self)
@@ -233,9 +235,8 @@ class Dependency():
 
     def disable(self):
         self.Enabled = False
-        if self.Done:
-            self.foreignDependency.Done = True
-        self.foreignDependency.Enabled = False
+        self.foreignDependency.Done = self.Done
+        self.foreignDependency.Enabled = self.Enabled
 
     def getMovement(self):
         raise NotImplementedError("Dependency class {} doesn't implement movement, use inherited classes instead!".format(self.__class__.__name__))

--- a/a2p_dependencies.py
+++ b/a2p_dependencies.py
@@ -345,8 +345,6 @@ class DependencyPointIdentity(Dependency):
         # These constraint have to be the last evaluated in the chain of constraints.
             
         tmpaxis = cleanAxis(create_Axis(self.refPoint, self.currentRigid.getRigidCenter()))
-        #dofpos = PointIdentityPos(tmpaxis,_dofPos,_pointconstraints)
-        #dofrot = PointIdentityRot(tmpaxis,_dofRot,_pointconstraints)
         return PointIdentity(tmpaxis, _dofPos, _dofRot, _pointconstraints)
                 
         
@@ -403,8 +401,6 @@ class DependencyPointOnLine(Dependency):
         #                        the pointconstraints which stores all point constraints of the rigid
         # These constraint have to be the last evaluated in the chain of c    
         tmpaxis = cleanAxis(create_Axis(self.refPoint, self.currentRigid.getRigidCenter()))
-        #dofpos = PointIdentityPos(tmpaxis,_dofPos,_pointconstraints)
-        #dofrot = PointIdentityRot(tmpaxis,_dofRot,_pointconstraints)
         return PointIdentity(tmpaxis, _dofPos, _dofRot, _pointconstraints)
                
 
@@ -462,9 +458,6 @@ class DependencyPointOnPlane(Dependency):
         # These constraint have to be the last evaluated in the chain of constraints.
                
         tmpaxis = cleanAxis(create_Axis(self.refPoint, self.currentRigid.getRigidCenter()))
-        
-        #dofpos = PointIdentityPos(tmpaxis,_dofPos,_pointconstraints)
-        #dofrot = PointIdentityRot(tmpaxis,_dofRot,_pointconstraints)
         return PointIdentity(tmpaxis, _dofPos, _dofRot, _pointconstraints)
         
 class DependencyCircularEdge(Dependency):
@@ -498,7 +491,7 @@ class DependencyCircularEdge(Dependency):
                 axis2.multiply(-1.0)
             self.refAxisEnd = self.refPoint.add(axis2)
             self.lockRotation = self.constraint.lockRotation
-            if abs(self.offset) > 1e-4: #solver.mySOLVER_SPIN_ACCURACY * 1e-1:
+            if abs(self.offset) > 1e-3: #solver.mySOLVER_SPIN_ACCURACY * 1e-1:
                 offsetAdjustVec = Base.Vector(axis2.x,axis2.y,axis2.z)
                 offsetAdjustVec.multiply(self.offset)
                 self.refPoint = self.refPoint.add(offsetAdjustVec)

--- a/a2p_rigid.py
+++ b/a2p_rigid.py
@@ -174,7 +174,7 @@ class Rigid():
                             for dep in self.depsPerLinkedRigids[j]: 
                                 #enable involved dep
                                 if not dep.Done and not dep.Enabled:
-                                    dep.enable([dep.currentRigid, dep.dependedRigid])
+                                    #dep.enable([dep.currentRigid, dep.dependedRigid])
                                     candidates.extend([dep.currentRigid, dep.dependedRigid])                                        
                                     DebugMsg(A2P_DEBUG_1, "        {}\n".format(dep))
                     #if len(outputRigidList)>0: #found something!
@@ -200,7 +200,7 @@ class Rigid():
                                 
                                 #enable involved dep
                                 if not dep.Done and not dep.Enabled:
-                                    dep.enable([dep.currentRigid, dep.dependedRigid])
+                                    #dep.enable([dep.currentRigid, dep.dependedRigid])
                                     candidates.extend([dep.currentRigid, dep.dependedRigid])
                                     #self.solvedCounter += 1
                                     DebugMsg(A2P_DEBUG_1, "        {}\n".format(dep))
@@ -216,7 +216,7 @@ class Rigid():
             if not self.tempfixed:
                 for dep in self.dependencies:
                     if not dep.Done and not dep.Enabled:
-                        dep.enable([dep.currentRigid, dep.dependedRigid])
+                        #dep.enable([dep.currentRigid, dep.dependedRigid])
                         DebugMsg(A2P_DEBUG_1, "        {}\n".format(dep))
                         candidates.extend([dep.currentRigid, dep.dependedRigid])
                 
@@ -286,10 +286,9 @@ class Rigid():
         newSpinCenter = Base.Vector(0,0,0)
         countRefPoints = 0
         for dep in self.dependencies:
-            if dep.Enabled:  #handle only enabled constraints
-                if dep.refPoint != None:
-                    newSpinCenter = newSpinCenter.add(dep.refPoint)
-                    countRefPoints += 1
+            if dep.refPoint != None:
+                newSpinCenter = newSpinCenter.add(dep.refPoint)
+                countRefPoints += 1
         if countRefPoints > 0:
             newSpinCenter.multiply(1.0/countRefPoints)
             self.spinCenter = newSpinCenter
@@ -322,18 +321,18 @@ class Rigid():
         self.moveVectorSum = Base.Vector(0,0,0)
 
         for dep in self.dependencies:
-            
-            refPoint, moveVector = dep.getMovement()
-            if refPoint is None or moveVector is None: continue     # Should not happen
-
-            depRefPoints.append(refPoint)
-            depMoveVectors.append(moveVector)
-
-            # Calculate max move error
-            if moveVector.Length > self.maxPosError: self.maxPosError = moveVector.Length
-
-            # Accomulate all the movements for later average calculations
-            self.moveVectorSum = self.moveVectorSum.add(moveVector)
+            if dep.Enabled:
+                refPoint, moveVector = dep.getMovement()
+                if refPoint is None or moveVector is None: continue     # Should not happen
+    
+                depRefPoints.append(refPoint)
+                depMoveVectors.append(moveVector)
+    
+                # Calculate max move error
+                if moveVector.Length > self.maxPosError: self.maxPosError = moveVector.Length
+    
+                # Accomulate all the movements for later average calculations
+                self.moveVectorSum = self.moveVectorSum.add(moveVector)
 
         # Calculate the average of all the movements
         if len(depMoveVectors) > 0:
@@ -366,20 +365,21 @@ class Rigid():
             #adjust axis' of the dependencies //FIXME (align,opposed,none)
 
             for dep in self.dependencies:
-                rotation = dep.getRotation(solver)
-
-                if rotation is None: continue       # No rotation for that dep
-
-                # Accumulate all rotations for later average calculation
-                self.spin = self.spin.add(rotation)
-                self.countSpinVectors += 1
-
-                # Calculate max rotation error
-                axisErr = self.spin.Length
-                if axisErr > self.maxAxisError : self.maxAxisError = axisErr
+                if dep.Enabled:
+                    rotation = dep.getRotation(solver)
+    
+                    if rotation is None: continue       # No rotation for that dep
+    
+                    # Accumulate all rotations for later average calculation
+                    self.spin = self.spin.add(rotation)
+                    self.countSpinVectors += 1
+    
+                    # Calculate max rotation error
+                    axisErr = self.spin.Length
+                    if axisErr > self.maxAxisError : self.maxAxisError = axisErr
 
     def move(self,doc):
-        if self.tempfixed or self.fixed: return
+        if self.tempfixed: return
         #
         #Linear moving of a rigid
         moveDist = Base.Vector(0,0,0)

--- a/a2p_rigid.py
+++ b/a2p_rigid.py
@@ -122,7 +122,7 @@ class Rigid():
     def enableDependencies(self, workList):
         for dep in self.dependencies:
             dep.enable(workList)
-            dep.calcRefPoints(dep.index)
+            #dep.calcRefPoints(dep.index)
 
     # The function only sets parentship for childrens that are distant+1 from fixed rigid
     # The function should be called in a loop with increased distance until it return False
@@ -164,25 +164,47 @@ class Rigid():
         candidates = []
         
         if solverStage == PARTIAL_SOLVE_STAGE1:
-            if not self.tempfixed:
-                if self.linkedTempFixedDOF():
-                    for linkedRig in self.linkedRigids:
-                        if linkedRig.tempfixed: #found a fully constrained obj to tempfixed rigids
-                            for dep in self.depsPerLinkedRigids[linkedRig]: 
+            if not self.tempfixed: #skip already fixed objs
+                #print 'current dof = ', rig.currentDOF()
+                #DebugMsg(A2P_DEBUG_1, "    {}\n".format(self.label))
+                a = self.label
+                if self.linkedTempFixedDOF()==0: #found a fully constrained obj to tempfixed rigids
+                    for j in self.depsPerLinkedRigids.keys(): #look on each linked obj
+                        if j.tempfixed: #the linked rigid is already fixed
+                            for dep in self.depsPerLinkedRigids[j]: 
                                 #enable involved dep
-                                if not dep.Done:
+                                if not dep.Done and not dep.Enabled:
                                     dep.enable([dep.currentRigid, dep.dependedRigid])
-                            candidates.append(linkedRig)
+                                    candidates.extend([dep.currentRigid, dep.dependedRigid])                                        
+                                    DebugMsg(A2P_DEBUG_1, "        {}\n".format(dep))
+                    #if len(outputRigidList)>0: #found something!
+                        #print '        Solve them!'                            
+            
                     
-        elif solverStage == PARTIAL_SOLVE_STAGE2:
-            for linkedRig in self.linkedRigids:
-                if linkedRig.tempfixed: continue
-                if linkedRig.areAllParentTempFixed():
-                    for dep in self.depsPerLinkedRigids[linkedRig]: 
-                        #enable involved dep
-                        if not dep.Done:
-                            dep.enable([dep.currentRigid, dep.dependedRigid])
-                    candidates.append(linkedRig)
+        elif solverStage == PARTIAL_SOLVE_STAGE2:  
+            #solve all rigid constrained ONLY to tempfixed rigid, 
+            #enable only involved dep, then set them as tempfixed        
+            
+            if not self.tempfixed: #skip already fixed objs  
+                                
+                if self.areAllParentTempFixed(): #linked only to fixed rigids                                                
+                    DebugMsg(A2P_DEBUG_1, "    {}\n".format(self.label))
+                    #print rig.linkedRigids 
+                    if not self.checkIfAllDone():                              
+                        #all linked rigid are tempfixed, so solve it now    
+                        #print rig.label
+                        for j in self.depsPerLinkedRigids.keys(): #look again on each linked obj
+                            #outputRigidList.append(j)
+                            #print 'Rigid ', j.label
+                            for dep in self.depsPerLinkedRigids[j]: 
+                                
+                                #enable involved dep
+                                if not dep.Done and not dep.Enabled:
+                                    dep.enable([dep.currentRigid, dep.dependedRigid])
+                                    candidates.extend([dep.currentRigid, dep.dependedRigid])
+                                    #self.solvedCounter += 1
+                                    DebugMsg(A2P_DEBUG_1, "        {}\n".format(dep))
+            
         
         elif solverStage == PARTIAL_SOLVE_STAGE3:
             pass
@@ -191,15 +213,16 @@ class Rigid():
             pass
 
         elif solverStage == PARTIAL_SOLVE_STAGE5:
-            for linkedRig in self.linkedRigids:
-                if linkedRig.tempfixed: continue
-                for dep in self.depsPerLinkedRigids[linkedRig]: 
-                    #enable involved dep
-                    if not dep.Done:
+            if not self.tempfixed:
+                for dep in self.dependencies:
+                    if not dep.Done and not dep.Enabled:
                         dep.enable([dep.currentRigid, dep.dependedRigid])
-                candidates.append(linkedRig)
+                        DebugMsg(A2P_DEBUG_1, "        {}\n".format(dep))
+                        candidates.extend([dep.currentRigid, dep.dependedRigid])
+                
 
-        return set(candidates)
+        #candidates = list(set(candidates))
+        return candidates#something match, return it to solver
     
     def addChildrenByDistance(self, addList, distance):
         # Current rigid is the father of the needed distance, so it might have needed children
@@ -231,6 +254,7 @@ class Rigid():
         # Update dependencies
         for dep in self.dependencies:
             dep.applyPlacement(pl)
+            #dep.calcRefPoints(dep.index)
 
     def clear(self):
         for d in self.dependencies:
@@ -298,18 +322,18 @@ class Rigid():
         self.moveVectorSum = Base.Vector(0,0,0)
 
         for dep in self.dependencies:
-            if dep.Enabled:  #handle only enable constraints
-                refPoint, moveVector = dep.getMovement()
-                if refPoint is None or moveVector is None: continue     # Should not happen
-    
-                depRefPoints.append(refPoint)
-                depMoveVectors.append(moveVector)
-    
-                # Calculate max move error
-                if moveVector.Length > self.maxPosError: self.maxPosError = moveVector.Length
-    
-                # Accomulate all the movements for later average calculations
-                self.moveVectorSum = self.moveVectorSum.add(moveVector)
+            
+            refPoint, moveVector = dep.getMovement()
+            if refPoint is None or moveVector is None: continue     # Should not happen
+
+            depRefPoints.append(refPoint)
+            depMoveVectors.append(moveVector)
+
+            # Calculate max move error
+            if moveVector.Length > self.maxPosError: self.maxPosError = moveVector.Length
+
+            # Accomulate all the movements for later average calculations
+            self.moveVectorSum = self.moveVectorSum.add(moveVector)
 
         # Calculate the average of all the movements
         if len(depMoveVectors) > 0:
@@ -342,23 +366,20 @@ class Rigid():
             #adjust axis' of the dependencies //FIXME (align,opposed,none)
 
             for dep in self.dependencies:
-                if dep.Enabled:  #handle only enable constraints
-                    rotation = dep.getRotation(solver)
-    
-                    if rotation is None: continue       # No rotation for that dep
-    
-                    
-    
-                    # Accumulate all rotations for later average calculation
-                    self.spin = self.spin.add(rotation)
-                    self.countSpinVectors += 1
-                    
-                    # Calculate max rotation error
-                    axisErr = self.spin.Length
-                    if axisErr > self.maxAxisError : self.maxAxisError = axisErr
+                rotation = dep.getRotation(solver)
+
+                if rotation is None: continue       # No rotation for that dep
+
+                # Accumulate all rotations for later average calculation
+                self.spin = self.spin.add(rotation)
+                self.countSpinVectors += 1
+
+                # Calculate max rotation error
+                axisErr = self.spin.Length
+                if axisErr > self.maxAxisError : self.maxAxisError = axisErr
 
     def move(self,doc):
-        if self.tempfixed or not self.checkIfInvolved(): return
+        if self.tempfixed or self.fixed: return
         #
         #Linear moving of a rigid
         moveDist = Base.Vector(0,0,0)
@@ -422,7 +443,7 @@ class Rigid():
     
     
     def linkedTempFixedDOF(self):
-        pointConstraints = []
+        self.pointConstraints = []
         _dofPos = a2p_libDOF.initPosDOF
         _dofRot = a2p_libDOF.initRotDOF
         self.reorderDependencies()

--- a/a2p_solversystem.py
+++ b/a2p_solversystem.py
@@ -466,8 +466,8 @@ class SolverSystem():
         if A2P_DEBUG_LEVEL >= A2P_DEBUG_1:
             self.printList("WorkList", workList)
 
-        #for rig in workList:
-        #    rig.enableDependencies(workList)
+        for rig in workList:
+            rig.enableDependencies(workList)
 
         self.lastPositionError = SOLVER_CONVERGENCY_ERROR_INIT_VALUE
         self.lastAxisError = SOLVER_CONVERGENCY_ERROR_INIT_VALUE
@@ -630,10 +630,10 @@ def solveConstraints( doc, cache=None ):
     ss = SolverSystem()
     ss.solveSystem(doc)
     doc.commitTransaction()
-    try:
-        doc.recompute()
-    except:
-        pass
+    #try:
+        #doc.recompute()
+    #except:
+    #    pass
     
 def autoSolveConstraints( doc, cache=None):
     if not a2plib.getAutoSolveState():

--- a/a2p_solversystem.py
+++ b/a2p_solversystem.py
@@ -50,6 +50,7 @@ from a2p_dependencies import Dependency
 from a2p_rigid import Rigid
 import os, sys
 from os.path import expanduser
+from test.test_MimeWriter import OUTPUT
 
 
 SOLVER_MAXSTEPS = 300000
@@ -106,6 +107,9 @@ class SolverSystem():
         return None
 
     def loadSystem(self,doc):
+        
+        #import sys;sys.path.append(r'C:\Users\Turro\.p2\pool\plugins\org.python.pydev.core_6.4.4.201807281807\pysrc')
+        #import pydevd;pydevd.settrace()
         self.clear()
         self.doc = doc
         self.status = "loading"
@@ -202,35 +206,35 @@ class SolverSystem():
         '''
         for rig in self.rigids:   
                      
-            #if not rig.tempfixed:  #skip already fixed objs
+            if not rig.tempfixed:  #skip already fixed objs
 
-            for linkedRig in rig.linkedRigids:
-                tmplinkedDeps = []
-                tmpLinkedPointDeps = []
-                for dep in rig.dependencies:
-                    if linkedRig==dep.dependedRigid:
-                        #be sure pointconstraints are at the end of the list
-                        if dep.isPointConstraint :
-                            tmpLinkedPointDeps.append(dep)
-                        else:
-                            tmplinkedDeps.append(dep)
-                #add at the end the point constraints
-                tmplinkedDeps.extend(tmpLinkedPointDeps) 
-                rig.depsPerLinkedRigids[linkedRig] = tmplinkedDeps
-        
-            #dofPOSPerLinkedRigid is a dict where for each 
-            for linkedRig in rig.depsPerLinkedRigids.keys():
-                linkedRig.pointConstraints = []
-                _dofPos = linkedRig.posDOF
-                _dofRot = linkedRig.rotDOF
-                for dep in rig.depsPerLinkedRigids[linkedRig]:
-                    _dofPos, _dofRot = dep.calcDOF(_dofPos,_dofRot, linkedRig.pointConstraints)
-                rig.dofPOSPerLinkedRigids[linkedRig] = _dofPos
-                rig.dofROTPerLinkedRigids[linkedRig] = _dofRot
+                for linkedRig in rig.linkedRigids:
+                    tmplinkedDeps = []
+                    tmpLinkedPointDeps = []
+                    for dep in rig.dependencies:
+                        if linkedRig==dep.dependedRigid:
+                            #be sure pointconstraints are at the end of the list
+                            if dep.isPointConstraint :
+                                tmpLinkedPointDeps.append(dep)
+                            else:
+                                tmplinkedDeps.append(dep)
+                    #add at the end the point constraints
+                    tmplinkedDeps.extend(tmpLinkedPointDeps) 
+                    rig.depsPerLinkedRigids[linkedRig] = tmplinkedDeps
             
-            #ok each rigid has a dict for each linked objects,
-            #so we now know the list of linked objects and which 
-            #dof rot and pos both limits.
+                #dofPOSPerLinkedRigid is a dict where for each 
+                for linkedRig in rig.depsPerLinkedRigids.keys():
+                    linkedRig.pointConstraints = []
+                    _dofPos = linkedRig.posDOF
+                    _dofRot = linkedRig.rotDOF
+                    for dep in rig.depsPerLinkedRigids[linkedRig]:
+                        _dofPos, _dofRot = dep.calcDOF(_dofPos,_dofRot, linkedRig.pointConstraints)
+                    rig.dofPOSPerLinkedRigids[linkedRig] = _dofPos
+                    rig.dofROTPerLinkedRigids[linkedRig] = _dofRot
+                
+                #ok each rigid has a dict for each linked objects,
+                #so we now know the list of linked objects and which 
+                #dof rot and pos both limits.
             
 
 
@@ -317,6 +321,7 @@ class SolverSystem():
         if self.status == "loadingDependencyError":
             return
         self.assignParentship(doc)
+        self.prepareRestart()
         loadTime = int(round(time.time() * 1000))
         while True:
             systemSolved = self.calculateChain(doc, mode)
@@ -328,7 +333,7 @@ class SolverSystem():
             if systemSolved:
                 self.mySOLVER_SPIN_ACCURACY *= 1e-1
                 self.mySOLVER_POS_ACCURACY *= 1e-1
-                Msg( '--->LEVEL OF ACCURACY :{}\n'.format(self.level_of_accuracy) )
+                Msg( '--->LEVEL OF ACCURACY :{} DONE!\n'.format(self.level_of_accuracy) )
                 self.level_of_accuracy+=1
                 if self.level_of_accuracy == MAX_LEVEL_ACCURACY:
                     self.solutionToParts(doc)
@@ -354,10 +359,10 @@ class SolverSystem():
         if self.status == "loadingDependencyError":
             return
 
-        if not systemSolved and mode == 'partial':
-            Msg( "Could not solve system with partial processing, switch to 'magnetic' mode  \n" )
-            mode = 'magnetic'
-            systemSolved = self.solveSystemWithMode(doc,mode)
+        #if not systemSolved and mode == 'partial':
+        #    Msg( "Could not solve system with partial processing, switch to 'magnetic' mode  \n" )
+        #    mode = 'magnetic'
+        #    systemSolved = self.solveSystemWithMode(doc,mode)
         if systemSolved:
             
             self.status = "solved"
@@ -388,42 +393,62 @@ class SolverSystem():
         self.stepCount = 0
         haveMore = True
         workList = []
-        workList.extend(self.rigids)
-        
+        #workList.extend(self.rigids)
+        self.partialSolverCurrentStage = PARTIAL_SOLVE_STAGE1
         if mode == 'partial':
             # start from fixed rigids and its children
-            self.solvedCounter = 0
+            
             while self.partialSolverCurrentStage != PARTIAL_SOLVE_END:
                 #print "evaluating stage = ", self.partialSolverCurrentStage
-                #print 'Tempfixed objs:'
-                '''for i in self.rigids:
-                    if i.tempfixed:
-                        print '    ',i.label'''
-                while True:
-                    
-                    if self.calculateChainByPartialStage(self.partialSolverCurrentStage)== False: 
-                        break
-                    else:
-                        #print "found something to solve at stage = ", currentstage
-                        #some rigid match stage 1, try solving
+                DebugMsg(A2P_DEBUG_1, "Evaluating stage = {}\n".format(self.partialSolverCurrentStage))
+                DebugMsg(A2P_DEBUG_1, "Tempfixed objs:\n")
+                if A2P_DEBUG_LEVEL>=A2P_DEBUG_1:
+                    for i in self.rigids:
+                        if i.tempfixed:
+                            DebugMsg(A2P_DEBUG_1,"    {}\n".format(i.label))
+                DebugMsg(A2P_DEBUG_1, "End of Tempfixed objs\n")
+                
+                while True: 
+                    somethingFound = False
+                    workList=[] 
+                    myCounter = len(self.rigids)                  
+                    for rig in self.rigids:
+                        #somethingFound = False
+                        workList.extend(rig.getCandidates(self.partialSolverCurrentStage))
+                        myCounter-=1
+                        workList = list(set(workList))
+                        if ((self.partialSolverCurrentStage==PARTIAL_SOLVE_STAGE5) and (myCounter>0)):
+                            continue
+                        if len(workList)> 0:
+                            somethingFound = True
+                            solutionFound = self.calculateWorkList(doc, workList, mode)
+                            #solutionFound = True
+                            if not solutionFound: 
+                                return False
+                            else:
+                                #partial system successfully solved, set as Done and disable
+                                #print 'Solution found'
+                                #FreeCADGui.updateGui()
+                                for rig in workList:
+                                    if self.partialSolverCurrentStage == PARTIAL_SOLVE_STAGE1:
+                                        rig.tempfixed=True
+                                    for dep in rig.dependencies:
+                                        if dep.Enabled:
+                                            dep.Done = True
+                                            dep.disable()
+                                            #rig.tempfixed = True
+                                workList=[]
+                    if not somethingFound:
+                        self.partialSolverCurrentStage +=1
+                        workList = []
+                        break 
                         
                         
-                        solutionFound = self.calculateWorkList(doc, workList, mode)
-                        if not solutionFound: 
-                            return False
-                        else:
-                            #partial system successfully solved, set as Done and disable
-                            #print 'Solution found'
-                            #FreeCADGui.updateGui()
-                            for rig in self.rigids:
-                                for dep in rig.dependencies:
-                                    if dep.Enabled:
-                                        dep.Done = True
-                                        dep.disable()
-                                        #rig.tempfixed = True
                     
         else:
-            #enable all dependencies, set all as done=false
+            # all dependencies, set all as done=false
+            workList = []
+            workList.extend(self.rigids)
             self.partialSolverCurrentStage = PARTIAL_SOLVE_END
             for rig in self.rigids:
                 rig.tempfixed = rig.fixed
@@ -459,12 +484,14 @@ class SolverSystem():
             self.convergencyCounter += 1
             # First calculate all the movement vectors
             for w in workList:
-                if w.checkIfInvolved():
-                    w.calcMoveData(doc, self)
-                    if w.maxPosError > maxPosError:
-                        maxPosError = w.maxPosError
-                    if w.maxAxisError > maxAxisError:
-                        maxAxisError = w.maxAxisError
+                #if w.checkIfInvolved():
+                    #for dep in w.dependencies:
+                    #    dep.calcRefPoints(dep.index)
+                w.calcMoveData(doc, self)
+                if w.maxPosError > maxPosError:
+                    maxPosError = w.maxPosError
+                if w.maxAxisError > maxAxisError:
+                    maxAxisError = w.maxAxisError
 
             # Perform the move
             for w in workList:                
@@ -482,21 +509,20 @@ class SolverSystem():
                 DebugMsg(A2P_DEBUG_1, "{} counts \n".format(calcCount) )
                 #self.prnPlacement()
                 
-                for r in workList:
-                    if r.checkIfInvolved():
-                        r.applySolution(doc, self)                        
-                        if self.partialSolverCurrentStage == PARTIAL_SOLVE_STAGE1:
-                            #print r.label , ' set as Tempfixed'
-                            r.tempfixed = True
-                        elif r.checkIfAllDone():
-                            r.tempfixed = True
+                for r in workList:                    
+                    r.applySolution(doc, self)                        
+                    if self.partialSolverCurrentStage == PARTIAL_SOLVE_STAGE1:
+                        #print r.label , ' set as Tempfixed'
+                        r.tempfixed = True
+                    elif r.checkIfAllDone():
+                        r.tempfixed = True
                  
                     
                 #self.prnPlacement()
             if self.convergencyCounter > SOLVER_STEPS_CONVERGENCY_CHECK:
                 if (
-                    maxPosError  > self.lastPositionError  or
-                    maxAxisError > self.lastAxisError
+                    maxPosError  >= self.lastPositionError   or
+                    maxAxisError >= self.lastAxisError 
                     ):
                     Msg( "System not solvable, convergency is incorrect!\n" )
                     return False
@@ -516,7 +542,7 @@ class SolverSystem():
             rig.applySolution(doc, self);
             
             
-    def calculateChainByPartialStage(self, currentstage): 
+    '''def calculateChainByPartialStage(self, currentstage): 
         outputRigidList = []       
         
         if currentstage == PARTIAL_SOLVE_STAGE1:  
@@ -524,24 +550,24 @@ class SolverSystem():
             for rig in self.rigids:
                 if not rig.tempfixed: #skip already fixed objs
                     #print 'current dof = ', rig.currentDOF()
-                    #print rig.label
+                    DebugMsg(A2P_DEBUG_1, "    {}\n".format(rig.label))
                     if rig.linkedTempFixedDOF()==0: #found a fully constrained obj to tempfixed rigids
-                        
                         for j in rig.depsPerLinkedRigids.keys(): #look on each linked obj
                             if j.tempfixed: #the linked rigid is already fixed
-                                outputRigidList.append(j)
                                 for dep in rig.depsPerLinkedRigids[j]: 
                                     #enable involved dep
-                                    if not dep.Done:
+                                    if not dep.Done and not dep.Enabled:
                                         dep.enable([dep.currentRigid, dep.dependedRigid])
-                                        
-                                        #print '        ',dep
-                        if len(outputRigidList)>0: #found something!
+                                        outputRigidList.extend([dep.currentRigid, dep.dependedRigid])                                        
+                                        DebugMsg(A2P_DEBUG_1, "        {}\n".format(dep))
+                        #if len(outputRigidList)>0: #found something!
                             #print '        Solve them!'                            
-                            return True #something match, return it to solver
+                        outputRigidList = list(set(outputRigidList))
+                        if len(outputRigidList)>0:
+                            return outputRigidList#something match, return it to solver
             
             self.partialSolverCurrentStage = PARTIAL_SOLVE_STAGE2
-            return False #nothing match, jump to next stage
+            return [] #nothing match, jump to next stage
          
         elif currentstage == PARTIAL_SOLVE_STAGE2:  
             #solve all rigid constrained ONLY to tempfixed rigid, 
@@ -550,35 +576,36 @@ class SolverSystem():
                 if not rig.tempfixed: #skip already fixed objs  
                                     
                     if rig.areAllParentTempFixed(): #linked only to fixed rigids                                                
-                        #print rig.label 
+                        DebugMsg(A2P_DEBUG_1, "    {}\n".format(rig.label))
                         #print rig.linkedRigids 
                         if not rig.checkIfAllDone():                              
                             #all linked rigid are tempfixed, so solve it now    
                             #print rig.label
                             for j in rig.depsPerLinkedRigids.keys(): #look again on each linked obj
-                                outputRigidList.append(j)
+                                #outputRigidList.append(j)
                                 #print 'Rigid ', j.label
                                 for dep in rig.depsPerLinkedRigids[j]: 
                                     
                                     #enable involved dep
-                                    if not dep.Done:
+                                    if not dep.Done and not dep.Enabled:
                                         dep.enable([dep.currentRigid, dep.dependedRigid])
+                                        outputRigidList.extend([dep.currentRigid, dep.dependedRigid])
                                         #self.solvedCounter += 1
-                                        #print '        ',dep
-                    if len(outputRigidList)>0: #found something!
-                        #print '        Solve them!'
-                        return True #something match
+                                        DebugMsg(A2P_DEBUG_1, "        {}\n".format(dep))
+                    outputRigidList = list(set(outputRigidList))
+                    if len(outputRigidList)>0:
+                        return outputRigidList#something match, return it to solver
             
             self.partialSolverCurrentStage = PARTIAL_SOLVE_STAGE3
-            return False #nothing match, jump to next stage                       
+            return []#nothing match, jump to next stage                       
                             
         elif currentstage == PARTIAL_SOLVE_STAGE3:
             self.partialSolverCurrentStage = PARTIAL_SOLVE_STAGE4
-            return False
+            return []
         
         elif currentstage == PARTIAL_SOLVE_STAGE4:
             self.partialSolverCurrentStage = PARTIAL_SOLVE_STAGE5
-            return False        
+            return []        
         
         elif currentstage == PARTIAL_SOLVE_STAGE5: 
             #enable all dep not marked as done
@@ -588,13 +615,14 @@ class SolverSystem():
                     for dep in rig.dependencies:
                         if not dep.Done and not dep.Enabled:
                             dep.enable([dep.currentRigid, dep.dependedRigid])
-                            #print '        ',dep
-                            tmpfound = True
+                            DebugMsg(A2P_DEBUG_1, "        {}\n".format(dep))
+                            outputRigidList.extend([dep.currentRigid, dep.dependedRigid])
+                            #tmpfound = True
             
             self.partialSolverCurrentStage = PARTIAL_SOLVE_END  
-            return tmpfound
+            return list(set(outputRigidList))
         else:
-            return False
+            return []'''
 
 #------------------------------------------------------------------------------
 def solveConstraints( doc, cache=None ):


### PR DESCRIPTION
created rigid.getcandidates and fixed rigid.calcspincenter

now it solves more than before, not everything, partial solving has and edge on some assemblies, imho it wrongly sets as tempfixed rigids that actually must left free.
DOF way become effective if objs are fully constrained.

I start developing stage 3 by introducing the super rigid entity, this would remove a lot of dep from stage 5.