### PR TITLE
fix to save and retrieve transparencies with "toggle tansparency" within

### DIFF
--- a/a2plib.py
+++ b/a2plib.py
@@ -101,10 +101,20 @@ def setTransparency():
         # Transparency is already saved, no need to set transparency again
         return
 
+#    SAVED_TRANSPARENCY = []                # reset it or not? better not, no need to do so.
+
     for obj in doc.Objects:
         if hasattr(obj,'ViewObject'):
             if hasattr(obj.ViewObject,'Transparency'):
-                SAVED_TRANSPARENCY.append((obj.Name, obj.ViewObject.Transparency))
+#                if hasattr(obj.ViewObject,'DiffuseColor'):
+                if ( len(obj.ViewObject.DiffuseColor) == 1 ) :
+                    print("setTransparency: ShapeColor and Transparency detected:\n", \
+                        obj.ViewObject.DiffuseColor)
+                else:
+                   print("setTransparency: muxed assembly detected:\n", \
+                       obj.ViewObject.DiffuseColor)
+                print("setTransparency: anyway, we save all color & transparency to be on the safe side"
+                SAVED_TRANSPARENCY.append((obj.Name, obj.ViewObject.Transparency, obj.ViewObject.DiffuseColor))
                 obj.ViewObject.Transparency = 80
 #------------------------------------------------------------------------------
 def restoreTransparency():
@@ -116,6 +126,7 @@ def restoreTransparency():
         obj = doc.getObject(setting[0])
         if obj is not None:
             obj.ViewObject.Transparency = setting[1]
+            obj.ViewObject.DiffuseColor = setting[2]
     SAVED_TRANSPARENCY = []
 #------------------------------------------------------------------------------
 def isTransparencyEnabled():


### PR DESCRIPTION
my approach

Hi @kbwbe,
I've managed to get the "toggle transparency" working for stage-1 assemblies. I just noticed that for subassemblies there is erratic behaviour left. "Show connected elements" works for them, but "toggle transparency" not. Strange... I'll investigate.

Please apply and test.
Thank you,
Manuel