### PR TITLE
improve-color-import: possible fix for color calculations with Python2 (integer division)

### DIFF
--- a/a2p_MuxAssembly.py
+++ b/a2p_MuxAssembly.py
@@ -55,7 +55,7 @@ def muxObjectsWithKeys(objsIn, withColor=False):
         # Save Computing time, store this before the for..enumerate loop later...
         colorFlag = ( len(obj.ViewObject.DiffuseColor) < len(obj.Shape.Faces) )    # one or more color tuples per obj ?
         shapeCol = obj.ViewObject.ShapeColor
-        shapeTsp = round( float(obj.ViewObject.Transparency/100), 2 )              # alpha value for DiffuseColor
+        shapeTsp = round( float(obj.ViewObject.Transparency/100.0), 2 )            # alpha value for DiffuseColor
         diffuseCol = copy.deepcopy(obj.ViewObject.DiffuseColor)
 
         # now start the loop with use of the stored values..(much faster)

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -246,7 +246,7 @@ def importPartFromFile(_doc, filename, importToCache=False):
         newObj.ViewObject.DiffuseColor = copy.deepcopy(tmpObj.ViewObject.DiffuseColor)
         print("importPartFromFile: initial DiffuseColor:\n", newObj.ViewObject.DiffuseColor)
 
-        shapeTsp = round( float(shapeTsp100/100), 2 )                         # setup DiffuseColor properly from Part
+        shapeTsp = round( float(shapeTsp100/100.0), 2 )                       # setup DiffuseColor properly from Part
         print("importPartFromFile: initial transparency:", shapeTsp)
         print("importPartFromFile: initial shapeColor:  ", shapeCol)
         print("importPartFromFile: DiffuseColor objects:", len(newObj.ViewObject.DiffuseColor))
@@ -409,7 +409,7 @@ def updateImportedParts(doc):
 
                     origDiffCol = copy.deepcopy(obj.ViewObject.DiffuseColor)        # DECIMAL ISSUE with transparency !!!
 
-                    origTsp = round( float(obj.ViewObject.Transparency/100), 2 )
+                    origTsp = round( float(obj.ViewObject.Transparency/100.0), 2 )
                     origShapeCol = obj.ViewObject.ShapeColor
                     print("updateImportedParts: orig Transparency:", origTsp)
                     print("updateImportedParts: orig ShapeColor:  ", origShapeCol)
@@ -504,7 +504,7 @@ def duplicateImportedPart( part ):
 
     newObj.ViewObject.ShapeColor = shapeCol = part.ViewObject.ShapeColor              # likely to override DiffuseColor if
     newObj.ViewObject.Transparency = shapeTsp100 = part.ViewObject.Transparency       # called later and most likely gray
-    shapeTsp = round( float(shapeTsp100/100), 2 )
+    shapeTsp = round( float(shapeTsp100/100.0), 2 )
     print("duplicateImportedPart: duplicated transparency:", shapeTsp)
     print("duplicateImportedPart: duplicated shapeColor:  ", shapeCol)
 


### PR DESCRIPTION
@kbwbe:
Hi Klaus,
as already mentioned and nearly proved by the fact that I cannot reproduce malfunction of color&transparency import, there only remained possible Python2/3 differences as reason (and bad coding from my side, of course).

As a first shot I've changed the calculation of transparecy to decimal/float.

Please apply and test,
best regards,
Manuel