### PR TITLE
Devel

### DIFF
--- a/GuiA2p/Resources/ui/a2p_prefs.ui
+++ b/GuiA2p/Resources/ui/a2p_prefs.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>705</width>
-    <height>512</height>
+    <height>731</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -60,67 +60,128 @@
            </property>
           </widget>
          </item>
+         <item>
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </widget>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Storage of files</string>
-     </property>
-     <widget class="QWidget" name="verticalLayoutWidget_3">
-      <property name="geometry">
-       <rect>
-        <x>49</x>
-        <y>40</y>
-        <width>537</width>
-        <height>171</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="Gui::PrefCheckBox" name="checkBox">
-         <property name="text">
-          <string>Use project-folder, all parts and assemblies have to be unique inside (experimetal)</string>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>useProjectFolder</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Gui::PrefFileChooser" name="fileChooser">
-         <property name="mode">
-          <enum>Gui::FileChooser::Directory</enum>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>projectFolder</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
    <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>default Solver Behaviour</string>
      </property>
+     <widget class="QGroupBox" name="groupBox_2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>140</y>
+        <width>687</width>
+        <height>234</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>Storage of files</string>
+      </property>
+      <widget class="QWidget" name="verticalLayoutWidget_3">
+       <property name="geometry">
+        <rect>
+         <x>49</x>
+         <y>40</y>
+         <width>537</width>
+         <height>171</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="Gui::PrefRadioButton" name="radioButton_3">
+          <property name="text">
+           <string>use relative pathes for imported parts</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>useRelativePathes</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/A2plus</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefRadioButton" name="radioButton_4">
+          <property name="text">
+           <string>use absolute pathes for imported parts</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>useAbsolutePathes</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/A2plus</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefRadioButton" name="radioButton_5">
+          <property name="text">
+           <string>Use project-folder, all files are below this</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>useProjectFolder</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/A2plus</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefFileChooser" name="fileChooser">
+          <property name="mode">
+           <enum>Gui::FileChooser::Directory</enum>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>projectFolder</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/A2plus</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
      <widget class="QWidget" name="verticalLayoutWidget">
       <property name="geometry">
        <rect>
-        <x>9</x>
-        <y>30</y>
+        <x>30</x>
+        <y>40</y>
         <width>521</width>
         <height>71</height>
        </rect>

--- a/InitGui.py
+++ b/InitGui.py
@@ -136,7 +136,8 @@ class a2pWorkbench (Workbench):
             )
 
         menuEntries = [
-            'a2p_repairTreeViewCommand'
+            'a2p_repairTreeViewCommand',
+            'a2p_absPath_to_relPath_Command'
             ]
         self.appendMenu(
             'A2p',

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You have to assemble existing projects again.
 Releases of A2plus available ?
 ------------------------------
 
-Not at moment. A2plus is in very early alpha state, but already functional for small projects.
+There are prereleases available. Please have a look at the releases section of this repository
 
 Known Issues:
 -------------
@@ -49,6 +49,9 @@ After that please constrain these parts again.
 This behaviour is due to FreeCAD's lack of topolocigal naming and is difficult to handle at moment.
 Some work will be done in future to improve this behaviour.
 
+Installation
+------------
+A2plus can now be installed by FreeCAD's add-on manager.
 
 Linux Installation Instructions
 -------------------------------

--- a/a2p_convertPart.py
+++ b/a2p_convertPart.py
@@ -58,6 +58,10 @@ def convertToImportedPart(doc, obj):
     
     newObj = doc.addObject("Part::FeaturePython",partName)
     newObj.Label = partLabel
+
+    newObj.Proxy = Proxy_convertPart()
+    newObj.ViewObject.Proxy = ImportedPartViewProviderProxy()
+
     newObj.addProperty("App::PropertyString", "a2p_Version","importPart").a2p_Version = A2P_VERSION
     newObj.addProperty("App::PropertyFile",    "sourceFile",    "importPart").sourceFile = filename
     newObj.addProperty("App::PropertyStringList","muxInfo","importPart")
@@ -74,15 +78,12 @@ def convertToImportedPart(doc, obj):
     newObj.muxInfo = createTopoInfo(obj)
 
     for p in obj.ViewObject.PropertiesList: 
-        if hasattr(newObj.ViewObject, p) and p not in ['DiffuseColor','Proxy','MappedColors']:
+        if hasattr(obj.ViewObject, p) and p not in ['DiffuseColor','Proxy','MappedColors']:
             setattr(newObj.ViewObject, p, getattr( obj.ViewObject, p))
     newObj.ViewObject.DiffuseColor = copy.copy( obj.ViewObject.DiffuseColor )
     newObj.ViewObject.Transparency = obj.ViewObject.Transparency
     newObj.Placement.Base = obj.Placement.Base
     newObj.Placement.Rotation = obj.Placement.Rotation
-
-    newObj.Proxy = Proxy_convertPart()
-    newObj.ViewObject.Proxy = ImportedPartViewProviderProxy()
 
     doc.removeObject(obj.Name)          # don't want the original in this doc anymore
     newObj.recompute()
@@ -153,5 +154,6 @@ Please select a Part.
 
 
 FreeCADGui.addCommand('a2p_ConvertPart',a2p_ConvertPartCommand())
+
 
 

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -569,7 +569,10 @@ This is not allowed when using preference
                 )
             return
         #TODO: WF fails if "use folder" = false here
-        docs = FreeCAD.listDocuments().values()
+        docs = []
+        for d in FreeCAD.listDocuments().values(): #dict_values not indexable, docs now is...
+            docs.append(d)
+        #docs = FreeCAD.listDocuments().values()
         docFilenames = [ d.FileName for d in docs ]
         
         if not fileNameWithinProjectFile in docFilenames :
@@ -584,7 +587,6 @@ This is not allowed when using preference
             for s in sub:
                 mdi.setActiveSubWindow(s)
                 if FreeCAD.activeDocument().Name == name: break
-            return
             # This does not work somehow...
             # FreeCAD.setActiveDocument( name )
             # FreeCAD.ActiveDocument=FreeCAD.getDocument( name )

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -386,11 +386,10 @@ def updateImportedParts(doc):
             if not hasattr( obj, 'muxInfo'):
                 obj.addProperty("App::PropertyStringList","muxInfo","importPart").muxInfo = []
 
-            oldSourceFile = obj.sourceFile # save for later restoring...
             assemblyPath = os.path.normpath(os.path.split(doc.FileName)[0])
-            replacement = a2plib.findSourceFileInProject(obj.sourceFile, assemblyPath)
+            absPath = a2plib.findSourceFileInProject(obj.sourceFile, assemblyPath)
 
-            if replacement == None:
+            if absPath == None:
                 QtGui.QMessageBox.critical(  QtGui.QApplication.activeWindow(),
                                             "Source file not found",
                                             "update of {} aborted!\nUnable to find {}".format(
@@ -398,19 +397,17 @@ def updateImportedParts(doc):
                                                 obj.sourceFile
                                                 )
                                         )
-            else:
-                obj.sourceFile = replacement # update Filepath, perhaps location changed !
 
-            if os.path.exists( obj.sourceFile ):
-                newPartCreationTime = os.path.getmtime( obj.sourceFile )
+            if os.path.exists( absPath ):
+                newPartCreationTime = os.path.getmtime( absPath )
                 DebugMsg(A2P_DEBUG_3,"a2p updateImportedParts: newPartCreationTime: {}\n".format(newPartCreationTime))
                 DebugMsg(A2P_DEBUG_3,"a2p updateImportedParts: obj.timeLastImport:  {}\n".format(obj.timeLastImport))
                 if ( newPartCreationTime >= obj.timeLastImport or    # changed behaviour to allow refresh ondemand
                     obj.a2p_Version != A2P_VERSION
                     ):
-                    if not objectCache.isCached(obj.sourceFile): # Load every changed object one time to cache
-                        importPartFromFile(doc, obj.sourceFile, importToCache=True) # the version is now in the cache
-                    newObject = objectCache.get(obj.sourceFile)
+                    if not objectCache.isCached(absPath): # Load every changed object one time to cache
+                        importPartFromFile(doc, absPath, importToCache=True) # the version is now in the cache
+                    newObject = objectCache.get(absPath)
                     obj.timeLastImport = newPartCreationTime
                     if hasattr(newObject, 'a2p_Version'):
                         obj.a2p_Version = newObject.a2p_Version
@@ -423,7 +420,6 @@ def updateImportedParts(doc):
                     obj.ViewObject.DiffuseColor = copy.copy(newObject.ViewObject.DiffuseColor)
                     obj.ViewObject.Transparency = newObject.ViewObject.Transparency
                     obj.Placement = savedPlacement # restore the old placement
-                obj.sourceFile = oldSourceFile # restore the old path (relative/absolute)
 
     mw = FreeCADGui.getMainWindow()
     mdi = mw.findChild(QtGui.QMdiArea)

--- a/a2p_sphericalConnection.py
+++ b/a2p_sphericalConnection.py
@@ -31,7 +31,7 @@ class SphericalSurfaceSelectionGate:
     def allow(self, doc, obj, sub):
         if sub.startswith('Face'):
             face = getObjectFaceFromName( obj, sub)
-            return str( face.Surface ).startswith('Sphere ')
+            return str( face.Surface ).startswith('Sphere')
         elif sub.startswith('Vertex'):
             return True
         else:

--- a/a2p_topomapper.py
+++ b/a2p_topomapper.py
@@ -1,0 +1,212 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2018 kbwbe                                              *
+#*                                                                         *
+#*   Portions of code based on hamish's assembly 2                         *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+'''
+Experimental mapper for a2p related topological naming.
+
+Recent capabilities:
+- create unique toponame for each vertex in a single body document
+
+Work in progress:
+- create unique toponame for each edge in a single body document
+
+Issues: globalPlacement ignored ATM
+
+Usage: start "a2p_toponamer.py" as makro ATM
+'''
+
+
+
+
+import FreeCAD, FreeCADGui, Part
+from FreeCAD import Base
+
+def filterShapeObs(_list):
+    lst = []
+    for ob in _list:
+        if hasattr(ob,"Shape"):
+            if len(ob.Shape.Faces) > 0:
+                lst.append(ob)
+    S = set(lst)
+    lst = []
+    lst.extend(S)
+    return lst
+
+
+class BodyTopoMapper(object):
+    
+    def __init__(self,bodyObject):
+        self.body = bodyObject
+        self.shapeSequence = []
+        self.vertexNameDict = {}
+        self.vertexNames = []
+        self.edgeNameDict = {}
+        self.edgeNames = []
+        #
+        self.calcShapeSequence()
+        self.setupVertexDict()
+        self.setupVertexNames()
+        self.setupEdgeDict()
+        
+    def calcVertexKey(self,vertex):
+        '''
+        create a unique key defined by vertex-position
+        '''
+        coords = (
+            vertex.Point.x,
+            vertex.Point.y,
+            vertex.Point.z
+            )
+        key = ''
+        for value in coords:
+            keyPartial = "%014.3f;" % value
+            key += keyPartial
+        return key
+    
+    def calcEdgeKeys(self,edge):
+        pass
+
+    def setupVertexNames(self):
+        feature = self.shapeSequence[-1]
+        self.vertexNames = []
+        print ("=== index/VertexName Map of last feature ===")
+        for i,vertex in enumerate(feature.Shape.Vertexes):
+            vertexKey = self.calcVertexKey(vertex)
+            vertexName = self.vertexNameDict[vertexKey]
+            self.vertexNames.append(vertexName)
+            print(str(i+1)+' '+vertexName)
+            
+    def setupEdgeDict(self):
+        totalNumEdges = 0
+        for feature in self.shapeSequence:
+            numNewlyCreatedEdges = len(feature.Shape.Edges) - totalNumEdges
+            totalNumEdges = len(feature.Shape.Vertexes)
+            edgeNamePrefix = self.body.Name + ';' + feature.Name + ';'
+            edgeNameSuffix = str(numNewlyCreatedEdges)
+            i = 0 # do not enumerate the following, count new vertexes !
+            for edge in feature.Shape.Edges:
+                edgeKeys = self.calcEdgeKeys(edge) # usually more than one key per edge
+                edgeName = edgeNamePrefix + str(i) + ';' + edgeNameSuffix
+
+    def setupVertexDict(self):
+        totalNumVertexes = 0
+        for feature in self.shapeSequence:
+            numNewlyCreatedVertexes = len(feature.Shape.Vertexes) - totalNumVertexes
+            totalNumVertexes = len(feature.Shape.Vertexes)
+            vertexNamePrefix = self.body.Name + ';' + feature.Name + ';'
+            vertexNameSuffix = str(numNewlyCreatedVertexes)
+            i = 0 # do not enumerate the following, count new vertexes !
+            for vertex in feature.Shape.Vertexes:
+                vertexKey = self.calcVertexKey(vertex)
+                vertexName = vertexNamePrefix + str(i) + ';' + vertexNameSuffix
+                vertexFound = self.vertexNameDict.get(vertexKey,False)
+                if vertexFound == False:
+                    self.vertexNameDict[vertexKey] = vertexName
+                    i+=1 # new vertex counting per feature
+
+    def calcShapeSequence(self):
+        self.shapeSequence = []
+        S = set(self.body.OutList)
+        shapedObs = []
+        for ob in S:
+            dependsOn = None
+            if hasattr(ob,"Shape"):
+                if len(ob.Shape.Faces) > 0:
+                    tmp = filterShapeObs(ob.OutList)
+                    if len(tmp)>0:
+                        dependsOn = tmp[0]
+                    shapedObs.append((ob,dependsOn))
+        #start with baseFeature
+        recentFeature = None
+        foundNew = False
+        for ob,dependsOn in shapedObs:
+            if not dependsOn: # dependsOn == None...
+                recentFeature = ob
+                foundNew = True
+                break
+        while foundNew:
+            self.shapeSequence.append(recentFeature)
+            foundNew = False
+            for ob,dependsOn in shapedObs:
+                if recentFeature == dependsOn:
+                    recentFeature = ob
+                    foundNew = True
+                    break
+        print("")
+        print("=== Feature creation history ===")
+        for s in self.shapeSequence:
+            print (s.Name)
+        print("")
+
+
+if __name__ == "__main__":
+    print ("a2p_topomapper v0.0.0")
+    print ("")
+    doc = FreeCAD.activeDocument()
+    obs = doc.Objects
+    for ob in obs:
+        if "Body" in ob.Name:
+            topoMap = BodyTopoMapper(ob)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/a2p_topomapper.py
+++ b/a2p_topomapper.py
@@ -76,6 +76,7 @@ class BodyTopoMapper(object):
         self.setupEdgeDict()
         self.setupEdgeNames()
         self.setupFaceDict()
+        self.setupFaceNames()
         
     def calcFloatKey(self,val):
             return "%014.3f;" % val
@@ -142,6 +143,23 @@ class BodyTopoMapper(object):
             vertexName = self.vertexNameDict[vertexKey]
             self.vertexNames.append(vertexName)
             print(str(i+1)+' '+vertexName)
+            
+    def setupFaceNames(self):
+        self.faceNames = []
+        if len(self.shapeSequence) == 0: return
+        feature = self.shapeSequence[-1]
+        print ("=== index/faceName Map of last feature ===")
+        for i,face in enumerate(feature.Shape.Faces):
+            faceKeys = self.calcFaceKeys(face)
+            for faceKey in faceKeys:
+                faceName = self.faceNameDict.get(faceKey,None)
+                if faceName != None:
+                    self.faceNames.append(faceName)
+                    print(str(i+1)+' '+faceName)
+                    break
+                else:
+                    self.faceNames.append("None")
+                    print(str(i+1)+" None")
             
     def calcEdgeKeys(self,edge):
         keys = []

--- a/a2p_topomapper.py
+++ b/a2p_topomapper.py
@@ -40,6 +40,7 @@ Usage: start "a2p_toponamer.py" as makro ATM
 
 import FreeCAD, FreeCADGui, Part
 from FreeCAD import Base
+import a2plib
 
 def filterShapeObs(_list):
     lst = []
@@ -67,6 +68,7 @@ class BodyTopoMapper(object):
         self.setupVertexDict()
         self.setupVertexNames()
         self.setupEdgeDict()
+        self.setupEdgeNames()
         
     def calcVertexKey(self,vertex):
         '''
@@ -83,9 +85,34 @@ class BodyTopoMapper(object):
             key += keyPartial
         return key
     
-    def calcEdgeKeys(self,edge):
-        pass
-
+    def calcAxisKey(self,axis):
+        '''
+        create a unique key defined by axis-direction
+        '''
+        coords = (
+            axis.x,
+            axis.y,
+            axis.z
+            )
+        key = ''
+        for value in coords:
+            keyPartial = "%012.9f;" % value
+            key += keyPartial
+        return key
+    
+    def setupEdgeNames(self):
+        feature = self.shapeSequence[-1]
+        self.edgeNames = []
+        print ("=== index/edgeName Map of last feature ===")
+        for i,edge in enumerate(feature.Shape.Edges):
+            edgeKeys = self.calcEdgeKeys(edge)
+            for edgeKey in edgeKeys:
+                edgeName = self.edgeNameDict.get(edgeKey,None)
+                if edgeName != None:
+                    self.edgeNames.append(edgeName)
+                    print(str(i+1)+' '+edgeName)
+                    break
+            
     def setupVertexNames(self):
         feature = self.shapeSequence[-1]
         self.vertexNames = []
@@ -96,17 +123,49 @@ class BodyTopoMapper(object):
             self.vertexNames.append(vertexName)
             print(str(i+1)+' '+vertexName)
             
+    def calcEdgeKeys(self,edge):
+        keys = []
+        endPoint1 = edge.Vertexes[0]
+        endPoint2 = edge.Vertexes[-1]
+        direction1 = endPoint2.Point.sub(endPoint1.Point)
+        direction2 = endPoint1.Point.sub(endPoint2.Point)
+        try:
+            direction1.normalize()
+            direction2.normalize()
+        except:
+            pass
+        keys.append(
+            self.calcVertexKey(endPoint1)+self.calcAxisKey(direction1)
+            )
+        keys.append(
+            self.calcVertexKey(endPoint2)+self.calcAxisKey(direction2)
+            )
+        return keys
+            
+
+
     def setupEdgeDict(self):
         totalNumEdges = 0
         for feature in self.shapeSequence:
             numNewlyCreatedEdges = len(feature.Shape.Edges) - totalNumEdges
-            totalNumEdges = len(feature.Shape.Vertexes)
+            totalNumEdges = len(feature.Shape.Edges)
             edgeNamePrefix = self.body.Name + ';' + feature.Name + ';'
             edgeNameSuffix = str(numNewlyCreatedEdges)
             i = 0 # do not enumerate the following, count new vertexes !
             for edge in feature.Shape.Edges:
                 edgeKeys = self.calcEdgeKeys(edge) # usually more than one key per edge
                 edgeName = edgeNamePrefix + str(i) + ';' + edgeNameSuffix
+                i+=1
+                entryFound=False
+                for k in edgeKeys:
+                    tmp = self.edgeNameDict.get(k,False)
+                    if tmp != False:
+                        entryFound = True
+                        break
+                if not entryFound:
+                    for k in edgeKeys:
+                        self.edgeNameDict[k] = edgeName
+                
 
     def setupVertexDict(self):
         totalNumVertexes = 0

--- a/a2p_viewProviderProxies.py
+++ b/a2p_viewProviderProxies.py
@@ -77,14 +77,12 @@ class ImportedPartViewProviderProxy:
         return None
 
     def attach(self, vobj):
-        default = coin.SoGroup()
-        vobj.addDisplayMode(default, "Standard")
         self.object_Name = vobj.Object.Name
         self.Object = vobj.Object
-        
 
     def setupContextMenu(self, ViewObject, popup_menu):
         pass
+
 
 class PopUpMenuItem:
     def __init__( self, proxy, menu, label, Freecad_cmd ):
@@ -127,6 +125,7 @@ class ConstraintViewProviderProxy:
     def getIcon(self):
         return self.iconPath
 
+#WF: next 3 methods not required
     def attach(self, vobj): #attach to what document?
         vobj.addDisplayMode( coin.SoGroup(),"Standard" )
 
@@ -167,6 +166,7 @@ class ConstraintMirrorViewProviderProxy:
     def getIcon(self):
         return self.iconPath
 
+#WF: next 3 methods not required
     def attach(self, vobj):
         vobj.addDisplayMode( coin.SoGroup(),"Standard" )
 
@@ -308,3 +308,4 @@ class ConstraintMirrorObjectProxy:
                         setattr( constraintObj, prop, getattr( obj, prop) )
                 except:
                     pass #loading issues...
+

--- a/a2plib.py
+++ b/a2plib.py
@@ -24,16 +24,18 @@
 
 import FreeCAD, FreeCADGui, Part
 from PySide import QtGui, QtCore
-import numpy, os
+import numpy, os, sys
 from a2p_viewProviderProxies import *
 from  FreeCAD import Base
 
+PYVERSION =  sys.version_info[0]
 
 preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/A2plus")
 
 USE_PROJECTFILE = preferences.GetBool('useProjectFolder', False)
 PARTIAL_PROCESSING_ENABLED = preferences.GetBool('usePartialSolver', True)
 AUTOSOLVE_ENABLED = preferences.GetBool('autoSolve', True)
+RELATIVE_PATHES_ENABLED = preferences.GetBool('useRelativePathes',True)
 
 SAVED_TRANSPARENCY = []
 
@@ -74,11 +76,13 @@ PARTIAL_SOLVE_END = 6
 
 
 #------------------------------------------------------------------------------
+def getRelativePathesEnabled():
+    global RELATIVE_PATHES_ENABLED
+    return RELATIVE_PATHES_ENABLED
+#------------------------------------------------------------------------------
 def setAutoSolve(enabled):
     global AUTOSOLVE_ENABLED
     AUTOSOLVE_ENABLED = enabled
-    #preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/A2plus")
-    #preferences.SetBool('autoSolve', enabled)
 #------------------------------------------------------------------------------
 def getAutoSolveState():
     return AUTOSOLVE_ENABLED
@@ -86,8 +90,6 @@ def getAutoSolveState():
 def setPartialProcessing(enabled):
     global PARTIAL_PROCESSING_ENABLED
     PARTIAL_PROCESSING_ENABLED = enabled
-    #preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/A2plus")
-    #preferences.SetBool('usePartialSolver', enabled)
 #------------------------------------------------------------------------------
 def isPartialProcessing():
     return PARTIAL_PROCESSING_ENABLED
@@ -205,8 +207,12 @@ def findSourceFileInProject(pathImportPart, assemblyPath):
 
     def findFile(name, path):
         for root, dirs, files in os.walk(path):
-            if name in files:
-                return os.path.join(root, name)
+            if PYVERSION < 3:
+                if str(name) in files:
+                    return os.path.join(root, name)
+            else:
+                if name in files:
+                    return os.path.join(root, name)
 
     projectFolder = os.path.abspath(getProjectFolder()) # get normalized path
     fileName = os.path.basename(pathImportPart)
@@ -222,8 +228,12 @@ def findInProject(pathImportPart):
     '''
     def findFile(name, path):
         for root, dirs, files in os.walk(path):
-            if name in files:
-                return os.path.join(root, name)
+            if PYVERSION < 3:
+                if str(name) in files:
+                    return os.path.join(root, name)
+            else:
+                if name in files:
+                    return os.path.join(root, name)
 
     projectFolder = os.path.abspath(getProjectFolder()) # get normalized path
     fileName = os.path.basename(pathImportPart)

--- a/a2plib.py
+++ b/a2plib.py
@@ -477,14 +477,6 @@ def getPos(obj, subElementName):
             # pos = surface.Position
         elif str(surface) == "<Cylinder object>":
             pos = surface.Center
-            '''
-            center = surface.Center
-            bb = face.BoundBox
-            if bb.isInside(center):
-                pos = center
-            else:
-                pos = bb.getIntersectionPoint(center, surface.Axis)
-            '''
         elif all( hasattr(surface,a) for a in ['Axis','Center','Radius'] ):
             pos = surface.Center
         elif str(surface).startswith('<SurfaceOfRevolution'):


### PR DESCRIPTION
A2plus now forces relative pathes for imported parts. On preferences page you can toggle between primary usage of absolute or relative pathes.

In A2p menu, there is a new tool to convert absolute pathes to relative ones.