### PR TITLE
added forceFixedPosition option on importing A2p parts

### DIFF
--- a/GuiA2p/Resources/ui/a2p_prefs.ui
+++ b/GuiA2p/Resources/ui/a2p_prefs.ui
@@ -61,6 +61,19 @@
           </widget>
          </item>
          <item>
+          <widget class="Gui::PrefCheckBox" name="checkBox_3">
+           <property name="text">
+            <string>force FixedPosition to all Imports</string>
+           </property>
+           <property name="prefEntry" stdset="0">
+            <cstring>forceFixedPosition</cstring>
+           </property>
+           <property name="prefPath" stdset="0">
+            <cstring>Mod/A2plus</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
             <enum>Qt::Vertical</enum>

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -183,7 +183,10 @@ def importPartFromFile(_doc, filename, importToCache=False):
     newObj.setEditorMode("timeLastImport",1)
     newObj.timeLastImport = os.path.getmtime( filename )
     newObj.addProperty("App::PropertyBool","fixedPosition","importPart")
-    newObj.fixedPosition = not any([i.fixedPosition for i in doc.Objects if hasattr(i, 'fixedPosition') ])
+    if a2plib.getForceFixedPosition():
+        newObj.fixedPosition = True
+    else:
+        newObj.fixedPosition = not any([i.fixedPosition for i in doc.Objects if hasattr(i, 'fixedPosition') ])
     newObj.addProperty("App::PropertyBool","subassemblyImport","importPart").subassemblyImport = subAssemblyImport
     newObj.setEditorMode("subassemblyImport",1)
     newObj.addProperty("App::PropertyBool","updateColors","importPart").updateColors = True

--- a/a2plib.py
+++ b/a2plib.py
@@ -36,6 +36,7 @@ USE_PROJECTFILE = preferences.GetBool('useProjectFolder', False)
 PARTIAL_PROCESSING_ENABLED = preferences.GetBool('usePartialSolver', True)
 AUTOSOLVE_ENABLED = preferences.GetBool('autoSolve', True)
 RELATIVE_PATHES_ENABLED = preferences.GetBool('useRelativePathes',True)
+FORCE_FIXED_POSITION = preferences.GetBool('forceFixedPosition',True)
 
 SAVED_TRANSPARENCY = []
 
@@ -64,6 +65,10 @@ A2P_DEBUG_LEVEL = A2P_DEBUG_NONE
 
 PARTIAL_SOLVE_STAGE1 = 1    #solve all rigid fully constrained to tempfixed rigid, enable only involved dep, then set them as tempfixed
 
+#------------------------------------------------------------------------------
+def getForceFixedPosition():
+    preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/A2plus")
+    return preferences.GetBool('forceFixedPosition',False)
 #------------------------------------------------------------------------------
 def getUseTopoNaming():
     preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/A2plus")


### PR DESCRIPTION
following this thread
[FreeCAD Forum -> Re: assembly without solver](https://forum.freecadweb.org/viewtopic.php?f=20&t=32843#p274624)
I have added a preference option to import new A2p part into an A2p document letting the Part to be placed at the original placement and with fixedPosition set to True.
This is useful for people creating assemblies with sub elements placed already at the correct position inside the assembly, and generating a fixed assembly without the need to add extra constraints.
