### PR TITLE
[improve-colors] heal preference collision for usePerFaceTransparency

### DIFF
--- a/GuiA2p/Resources/ui/a2p_prefs.ui
+++ b/GuiA2p/Resources/ui/a2p_prefs.ui
@@ -131,7 +131,7 @@
        <item>
         <widget class="Gui::PrefCheckBox" name="checkBox_7">
          <property name="text">
-          <string>inherit per face transparency from sub-assemblies</string>
+          <string>inherit per face transparency from parts and sub-assemblies (experimental)</string>
          </property>
          <property name="prefEntry" stdset="0">
           <cstring>usePerFaceTransparency</cstring>

--- a/a2plib.py
+++ b/a2plib.py
@@ -39,8 +39,6 @@ RELATIVE_PATHES_ENABLED = preferences.GetBool('useRelativePathes',True)
 FORCE_FIXED_POSITION = preferences.GetBool('forceFixedPosition',True)
 SHOW_CONSTRAINTS_ON_TOOLBAR= preferences.GetBool('showConstraintsOnToolbar',True)
 RECURSIVE_UPDATE_ENABLED = preferences.GetBool('enableRecursiveUpdate',False)
-# temporary preference predecessor:
-PER_FACE_TRANSPARENCY = True
 
 SAVED_TRANSPARENCY = []
 
@@ -65,7 +63,7 @@ A2P_DEBUG_1         = 1
 A2P_DEBUG_2         = 2
 A2P_DEBUG_3         = 3
 
-A2P_DEBUG_LEVEL = A2P_DEBUG_3
+A2P_DEBUG_LEVEL = A2P_DEBUG_NONE
 
 PARTIAL_SOLVE_STAGE1 = 1    #solve all rigid fully constrained to tempfixed rigid, enable only involved dep, then set them as tempfixed
 CONSTRAINT_DIALOG_REF = None
@@ -115,10 +113,6 @@ def getRecursiveUpdateEnabled():
 def getForceFixedPosition():
     preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/A2plus")
     return preferences.GetBool('forceFixedPosition',False)
-#------------------------------------------------------------------------------
-def getPerFaceTransparency():
-    global PER_FACE_TRANSPARENCY
-    return PER_FACE_TRANSPARENCY
 #------------------------------------------------------------------------------
 def getConstraintEditorRef():
     global CONSTRAINT_EDITOR__REF


### PR DESCRIPTION
Just a quick fix for the newly implemented preference/ variable usage (+ reverting to standard debuglevel + adding "(experimental)" to the transparency preference).

Please check whether I did it correctly and in the desired style before accepting it !