### PR TITLE
complete preferences UI overhaul

### DIFF
--- a/GuiA2p/Resources/ui/a2p_prefs.ui
+++ b/GuiA2p/Resources/ui/a2p_prefs.ui
@@ -66,7 +66,7 @@
    <property name="title">
     <string>Behavior when updating imported parts</string>
    </property>
-   <widget class="QWidget" name="">
+   <widget class="QWidget" name="layoutWidget">
     <property name="geometry">
      <rect>
       <x>21</x>
@@ -192,7 +192,7 @@
      <rect>
       <x>20</x>
       <y>20</y>
-      <width>252</width>
+      <width>391</width>
       <height>101</height>
      </rect>
     </property>
@@ -246,7 +246,7 @@
       <widget class="Gui::PrefFileChooser" name="fileChooser">
        <property name="minimumSize">
         <size>
-         <width>250</width>
+         <width>350</width>
          <height>0</height>
         </size>
        </property>
@@ -324,7 +324,7 @@
    <property name="title">
     <string>Default solving method</string>
    </property>
-   <widget class="QWidget" name="">
+   <widget class="QWidget" name="layoutWidget">
     <property name="geometry">
      <rect>
       <x>20</x>

--- a/GuiA2p/Resources/ui/a2p_prefs.ui
+++ b/GuiA2p/Resources/ui/a2p_prefs.ui
@@ -6,438 +6,388 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>675</width>
-    <height>850</height>
+    <width>463</width>
+    <height>562</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>A2plus settings</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="4" column="0">
-    <widget class="QGroupBox" name="groupBox_4">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>100</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>User interface settings</string>
-     </property>
-     <widget class="QWidget" name="verticalLayoutWidget_4">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>30</y>
-        <width>621</width>
-        <height>41</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_5">
-       <item>
-        <widget class="Gui::PrefCheckBox" name="checkBox_6">
-         <property name="text">
-          <string>Show constraints in toolbar</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>showConstraintsOnToolbar</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>230</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Behavior when updating imported parts</string>
-     </property>
-     <widget class="QWidget" name="verticalLayoutWidget_3">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>30</y>
-        <width>621</width>
-        <height>200</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="Gui::PrefCheckBox" name="checkBox_4">
-         <property name="text">
-          <string>Recalculate imported parts before updating them (experimental)</string>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>recalculateImportedParts</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Gui::PrefCheckBox" name="checkBox_5">
-         <property name="text">
-          <string>Enable recursive update of imported parts</string>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>enableRecursiveUpdate</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Gui::PrefCheckBox" name="checkBox_2">
-         <property name="text">
-          <string>Use experimental topological naming</string>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>useTopoNaming</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Gui::PrefCheckBox" name="checkBox_7">
-         <property name="text">
-          <string>Inherit per face transparency from parts and subassemblies (experimental)</string>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>usePerFaceTransparency</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Gui::PrefCheckBox" name="checkBox_8">
-         <property name="text">
-          <string>Do not import invisible shapes (for expert users)</string>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>doNotImportInvisibleShapes</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Gui::PrefCheckBox" name="checkBox_9">
-         <property name="text">
-          <string>Use solid union for importing parts and subassemblies (experimental)</string>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>useSolidUnion</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>150</height>
-        </size>
+  <widget class="QGroupBox" name="groupBox_4">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>350</y>
+     <width>441</width>
+     <height>51</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>User interface settings</string>
+   </property>
+   <widget class="Gui::PrefCheckBox" name="checkBox_6">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>20</y>
+      <width>153</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="toolTip">
+     <string>Adds a creation button for every constraint type to the toolbar</string>
+    </property>
+    <property name="text">
+     <string>Show constraints in toolbar</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+    <property name="prefEntry" stdset="0">
+     <cstring>showConstraintsOnToolbar</cstring>
+    </property>
+    <property name="prefPath" stdset="0">
+     <cstring>Mod/A2plus</cstring>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QGroupBox" name="groupBox_3">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>170</y>
+     <width>441</width>
+     <height>171</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="title">
+    <string>Behavior when updating imported parts</string>
+   </property>
+   <widget class="QWidget" name="">
+    <property name="geometry">
+     <rect>
+      <x>21</x>
+      <y>20</y>
+      <width>391</width>
+      <height>134</height>
+     </rect>
+    </property>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="Gui::PrefCheckBox" name="checkBox_4">
+       <property name="toolTip">
+        <string>All parts of the assembly will be opened in FreeCAD to be reconstructed using values from spreadsheets</string>
        </property>
-       <property name="title">
-        <string>Default solving method</string>
+       <property name="text">
+        <string>Recalculate imported parts before updating them (experimental)</string>
        </property>
-       <widget class="QWidget" name="verticalLayoutWidget_2">
-        <property name="geometry">
-         <rect>
-          <x>19</x>
-          <y>29</y>
-          <width>621</width>
-          <height>111</height>
-         </rect>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
-          <widget class="Gui::PrefRadioButton" name="radioButton">
-           <property name="text">
-            <string>Use solving of partial systems (recommended for static assemblies)</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-           <property name="prefEntry" stdset="0">
-            <cstring>usePartialSolver</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-            <cstring>Mod/A2plus</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Gui::PrefRadioButton" name="radioButton_2">
-           <property name="text">
-            <string>Use &quot;magnetic&quot; solver, solving all parts at once (for dynamical assemblies)</string>
-           </property>
-           <property name="prefEntry" stdset="0">
-            <cstring>useMagneticSolver</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-            <cstring>Mod/A2plus</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Gui::PrefCheckBox" name="checkBox_3">
-           <property name="text">
-            <string>Force fixed position to all imports</string>
-           </property>
-           <property name="prefEntry" stdset="0">
-            <cstring>forceFixedPosition</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-            <cstring>Mod/A2plus</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
+       <property name="prefEntry" stdset="0">
+        <cstring>recalculateImportedParts</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="Gui::PrefCheckBox" name="checkBox_5">
+       <property name="toolTip">
+        <string>Opens all subassemblies recursively to update them</string>
+       </property>
+       <property name="text">
+        <string>Enable recursive update of imported parts</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>enableRecursiveUpdate</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="Gui::PrefCheckBox" name="checkBox_2">
+       <property name="toolTip">
+        <string>While importing parts to the assembly, the topological names are written into &quot;mux Info&quot; property. When the parts are later updated the properties &quot;Sub Elementx&quot; of the constraints will be updated according to the &quot;mux Info&quot; topology.</string>
+       </property>
+       <property name="text">
+        <string>Use experimental topological naming</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>useTopoNaming</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="Gui::PrefCheckBox" name="checkBox_7">
+       <property name="toolTip">
+        <string>Use color and transparency settings from imported parts</string>
+       </property>
+       <property name="text">
+        <string>Inherit per face transparency from parts and subassemblies (experimental)</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>usePerFaceTransparency</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="Gui::PrefCheckBox" name="checkBox_8">
+       <property name="toolTip">
+        <string>Invisible datum/construction shapes will be hidden. Note: No constraints must be connected to datum/construction shapes in higher or other subassemblies. Otherwise you can break the assembly.</string>
+       </property>
+       <property name="statusTip">
+        <string>All imported parts will directly be put together as union.</string>
+       </property>
+       <property name="text">
+        <string>Do not import invisible shapes (for expert users)</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>doNotImportInvisibleShapes</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="Gui::PrefCheckBox" name="checkBox_9">
+       <property name="text">
+        <string>Use solid union for importing parts and subassemblies (experimental)</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>useSolidUnion</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="5" column="0">
-    <widget class="QGroupBox" name="groupBox_6">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>200</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Storage of files</string>
-     </property>
-     <widget class="QWidget" name="verticalLayoutWidget_5">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>30</y>
-        <width>621</width>
-        <height>161</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_6">
-       <item>
-        <widget class="Gui::PrefRadioButton" name="radioButton_3">
-         <property name="text">
-          <string>Use relative paths for imported parts</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>useRelativePathes</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Gui::PrefRadioButton" name="radioButton_4">
-         <property name="text">
-          <string>Use absolute paths for imported parts</string>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>useAbsolutePathes</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Gui::PrefRadioButton" name="radioButton_5">
-         <property name="toolTip">
-          <string>Specify the project folder in the field below</string>
-         </property>
-         <property name="text">
-          <string>All files are in this project folder:</string>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>useProjectFolder</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Gui::PrefFileChooser" name="fileChooser">
-         <property name="minimumSize">
-          <size>
-           <width>250</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>400</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="mode">
-          <enum>Gui::FileChooser::Directory</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>100</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Default solver behavior</string>
-     </property>
-     <widget class="QWidget" name="verticalLayoutWidget">
-      <property name="geometry">
-       <rect>
-        <x>19</x>
-        <y>39</y>
-        <width>621</width>
-        <height>51</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="Gui::PrefCheckBox" name="checkBox">
-         <property name="text">
-          <string>Solve automatically if a constraint property is changed</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>autoSolve</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/A2plus</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <spacer name="verticalSpacer_5">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-  </layout>
+   </widget>
+  </widget>
+  <widget class="QGroupBox" name="groupBox_6">
+   <property name="geometry">
+    <rect>
+     <x>9</x>
+     <y>410</y>
+     <width>441</width>
+     <height>141</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Storage of files</string>
+   </property>
+   <widget class="QWidget" name="verticalLayoutWidget_5">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>20</y>
+      <width>252</width>
+      <height>101</height>
+     </rect>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_6">
+     <item>
+      <widget class="Gui::PrefRadioButton" name="radioButton_3">
+       <property name="text">
+        <string>Use relative paths for imported parts</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>useRelativePathes</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::PrefRadioButton" name="radioButton_4">
+       <property name="text">
+        <string>Use absolute paths for imported parts</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>useAbsolutePathes</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::PrefRadioButton" name="radioButton_5">
+       <property name="toolTip">
+        <string>Specify the project folder in the field below</string>
+       </property>
+       <property name="text">
+        <string>All files are in this project folder:</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>useProjectFolder</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::PrefFileChooser" name="fileChooser">
+       <property name="minimumSize">
+        <size>
+         <width>250</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="mode">
+        <enum>Gui::FileChooser::Directory</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_6">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QGroupBox" name="groupBox_2">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>110</y>
+     <width>441</width>
+     <height>51</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Default solver behavior</string>
+   </property>
+   <widget class="Gui::PrefCheckBox" name="checkBox">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>20</y>
+      <width>283</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Solve automatically if a constraint property is changed</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+    <property name="prefEntry" stdset="0">
+     <cstring>autoSolve</cstring>
+    </property>
+    <property name="prefPath" stdset="0">
+     <cstring>Mod/A2plus</cstring>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QGroupBox" name="groupBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>441</width>
+     <height>91</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Default solving method</string>
+   </property>
+   <widget class="QWidget" name="">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>20</y>
+      <width>384</width>
+      <height>65</height>
+     </rect>
+    </property>
+    <layout class="QFormLayout" name="formLayout_2">
+     <item row="0" column="0">
+      <widget class="Gui::PrefRadioButton" name="radioButton">
+       <property name="toolTip">
+        <string>Solver begins with a fixed part and a part constrained to it. All other parts are not calculated. If a solution could be found, the next constrained part is added for the calculation and so on.</string>
+       </property>
+       <property name="text">
+        <string>Use solving of partial systems (recommended for static assemblies)</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>usePartialSolver</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="Gui::PrefRadioButton" name="radioButton_2">
+       <property name="toolTip">
+        <string>Solver tries to move all parts at once in direction to a fixed part</string>
+       </property>
+       <property name="text">
+        <string>Use &quot;magnetic&quot; solver, solving all parts at once (for dynamical assemblies)</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>useMagneticSolver</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="Gui::PrefCheckBox" name="checkBox_3">
+       <property name="toolTip">
+        <string>All parts will be fixed to the positions where they were created</string>
+       </property>
+       <property name="text">
+        <string>Force fixed position to all imports</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>forceFixedPosition</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/A2plus</cstring>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>


### PR DESCRIPTION
- reduce whitespace
- remove unused elements

This is how it looks here on Windows:

![freecad_howa00lrds](https://user-images.githubusercontent.com/1828501/52907824-a56f4b00-3269-11e9-96c4-3185f91c9188.png)

(the file path is just an example to show that the space is sufficient also for long paths)