### PR TITLE
[A2plus-devel] correct some wording and orders for future compatibility

### DIFF
--- a/GuiA2p/Resources/ui/a2p_prefs.ui
+++ b/GuiA2p/Resources/ui/a2p_prefs.ui
@@ -136,10 +136,10 @@ will be updated according to the &quot;mux Info&quot; topology.</string>
 from imported parts</string>
        </property>
        <property name="text">
-        <string>Inherit per face transparency from parts and subassemblies (experimental)</string>
+        <string>Inherit transparency from parts/subassemblies (override with updateColors=false)</string>
        </property>
        <property name="prefEntry" stdset="0">
-        <cstring>usePerFaceTransparency</cstring>
+        <cstring>usePerPartTransparency</cstring>
        </property>
        <property name="prefPath" stdset="0">
         <cstring>Mod/A2plus</cstring>

--- a/a2p_convertPart.py
+++ b/a2p_convertPart.py
@@ -76,7 +76,7 @@ def convertToImportedPart(doc, obj):
     newObj.ViewObject.ShapeColor = obj.ViewObject.ShapeColor
     newObj.ViewObject.DiffuseColor = copy.copy( obj.ViewObject.DiffuseColor ) # diffuse needs to happen last
     
-    if not a2plib.getPerFaceTransparency():
+    if not a2plib.getPerPartTransparency():
         # switch of perFaceTransparency
         newObj.ViewObject.Transparency = 1
         newObj.ViewObject.Transparency = 0 # default = nontransparent

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -228,8 +228,9 @@ def importPartFromFile(_doc, filename, importToCache=False):
     if importToCache: # this import is used to update already imported parts
         objectCache.add(filename, newObj)
     else: # this is a first time import of a part
-        if not a2plib.getPerFaceTransparency():
-            # turn of perFaceTransparency by accessing ViewObject.Transparency and set to zero (non transparent)
+        if not a2plib.getPerPartTransparency():
+            # turn of perPartTransparency by accessing ViewObject.Transparency and set to zero (non transparent)
+#              Mmmmh? "turn of"?! turn on, off, around, refresh or override would be more meaningful - MK.
             newObj.ViewObject.Transparency = 1
             newObj.ViewObject.Transparency = 0 # import assembly first time as non transparent.
 
@@ -422,7 +423,7 @@ def updateImportedParts(doc):
                     savedPlacement  = obj.Placement
                     obj.Shape = newObject.Shape.copy()
                     obj.Placement = savedPlacement # restore the old placement
-                    a2plib.copyObjectColors(obj,newObject)
+                    a2plib.copyObjectColors(newObject,obj)    # order is: source,target !!! MK.
 
 
     mw = FreeCADGui.getMainWindow()

--- a/a2plib.py
+++ b/a2plib.py
@@ -129,9 +129,9 @@ def doNotImportInvisibleShapes():
     preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/A2plus")
     return preferences.GetBool('doNotImportInvisibleShapes',True)
 #------------------------------------------------------------------------------
-def getPerFaceTransparency():
+def getPerPartTransparency():
     preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/A2plus")
-    return preferences.GetBool('usePerFaceTransparency',False)
+    return preferences.GetBool('usePerPartTransparency',False)
 #------------------------------------------------------------------------------
 def getRecalculateImportedParts():
     preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/A2plus")
@@ -747,39 +747,39 @@ def isA2pObject(obj):
         result = True
     return result
 #------------------------------------------------------------------------------
-def makeDiffuseElement(color,trans):
-    elem = (color[0],color[1],color[2],trans/100.0)
+def makeDiffuseElement(color,transparency):
+    elem = (color[0],color[1],color[2],transparency/100.0)
     return elem
 #------------------------------------------------------------------------------
 def copyObjectColors(ob1,ob2):
     '''
-    copies colors from ob2 to ob1
+    copies colors from ob1 to ob2 (source,target)
     Transparency of updated object is not touched until
-    user activates perFaceTransparency within preferences.
+    user activates perPartTransparency within preferences.
     '''
     if ob1.updateColors != True:
         ob1.ViewObject.DiffuseColor = [ob1.ViewObject.ShapeColor] # set syncron
         return
     
     # obj1.updateColors == True from now
-    newDiffuseColor = copy.copy(ob2.ViewObject.DiffuseColor)
-    ob1.ViewObject.ShapeColor = ob2.ViewObject.ShapeColor
-    ob1.ViewObject.DiffuseColor = newDiffuseColor # set diffuse last
+    newDiffuseColor = copy.copy(ob1.ViewObject.DiffuseColor)
+    ob2.ViewObject.ShapeColor = ob1.ViewObject.ShapeColor
+    ob2.ViewObject.DiffuseColor = newDiffuseColor # set diffuse last
 
-    if not getPerFaceTransparency():
+    if not getPerPartTransparency():
         # touch transparency one to trigger update of 3D View
         # per face transparency probably gets lost
         if ob1.ViewObject.Transparency > 0:
             t = ob1.ViewObject.Transparency
-            ob1.ViewObject.Transparency = 0
-            ob1.ViewObject.Transparency = t
+            ob2.ViewObject.Transparency = 0
+            ob2.ViewObject.Transparency = t
         else:
-            ob1.ViewObject.Transparency = 1
-            ob1.ViewObject.Transparency = 0
+            ob2.ViewObject.Transparency = 1
+            ob2.ViewObject.Transparency = 0
 
     # select/unselect object once to trigger update of 3D View
-    FreeCADGui.Selection.addSelection(ob1)
-    FreeCADGui.Selection.removeSelection(ob1)
+    FreeCADGui.Selection.addSelection(ob2)
+    FreeCADGui.Selection.removeSelection(ob2)
 #------------------------------------------------------------------------------
 def isConstrainedPart(doc,obj):
     if not isA2pPart(obj): return False


### PR DESCRIPTION
Hi Klaus,
this is only a small fix what does what it should, according to the headline.
Please, have a look into it before applying!
I really need the difference of "perPartTransparency" and possible future modes like "perFaceColor" etc. for further development. Current state isn't meaningful enough, IMO.
And, I've changed the order of the files in and for "copyObjectColors(ob1,ob2)" to the widely used model (source,target).

BR
Manuel