### PR TITLE
A2plus-devel-proposals: Fix toggleTransparency and orders in copyObjectColors

### DIFF
--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -422,7 +422,7 @@ def updateImportedParts(doc):
                     savedPlacement  = obj.Placement
                     obj.Shape = newObject.Shape.copy()
                     obj.Placement = savedPlacement # restore the old placement
-                    a2plib.copyObjectColors(obj,newObject)
+                    a2plib.copyObjectColors(newObject,obj)    # order is: source,target  *MK.
 
 
     mw = FreeCADGui.getMainWindow()

--- a/a2plib.py
+++ b/a2plib.py
@@ -729,13 +729,13 @@ def isA2pObject(obj):
         result = True
     return result
 #------------------------------------------------------------------------------
-def makeDiffuseElement(color,trans):
-    elem = (color[0],color[1],color[2],trans/100.0)
+def makeDiffuseElement(color,transparency):
+    elem = (color[0],color[1],color[2],transparency/100.0)
     return elem
 #------------------------------------------------------------------------------
 def copyObjectColors(ob1,ob2):
     '''
-    copies colors from ob2 to ob1
+    copies colors from ob1 to ob2 (source,target)
     Transparency of updated object is not touched until
     user activates perFaceTransparency within preferences.
     '''
@@ -744,24 +744,24 @@ def copyObjectColors(ob1,ob2):
         return
     
     # obj1.updateColors == True from now
-    newDiffuseColor = copy.copy(ob2.ViewObject.DiffuseColor)
-    ob1.ViewObject.ShapeColor = ob2.ViewObject.ShapeColor
-    ob1.ViewObject.DiffuseColor = newDiffuseColor # set diffuse last
+    newDiffuseColor = copy.copy(ob1.ViewObject.DiffuseColor)
+    ob2.ViewObject.ShapeColor = ob1.ViewObject.ShapeColor
+    ob2.ViewObject.DiffuseColor = newDiffuseColor # set diffuse last
 
-    if not getPerFaceTransparency():
+    if not getPerPartTransparency():
         # touch transparency one to trigger update of 3D View
         # per face transparency probably gets lost
         if ob1.ViewObject.Transparency > 0:
             t = ob1.ViewObject.Transparency
-            ob1.ViewObject.Transparency = 0
-            ob1.ViewObject.Transparency = t
+            ob2.ViewObject.Transparency = 0
+            ob2.ViewObject.Transparency = t
         else:
-            ob1.ViewObject.Transparency = 1
-            ob1.ViewObject.Transparency = 0
+            ob2.ViewObject.Transparency = 1
+            ob2.ViewObject.Transparency = 0
 
     # select/unselect object once to trigger update of 3D View
-    FreeCADGui.Selection.addSelection(ob1)
-    FreeCADGui.Selection.removeSelection(ob1)
+    FreeCADGui.Selection.addSelection(ob2)
+    FreeCADGui.Selection.removeSelection(ob2)
 #------------------------------------------------------------------------------
 def isConstrainedPart(doc,obj):
     if not isA2pPart(obj): return False

--- a/a2plib.py
+++ b/a2plib.py
@@ -748,7 +748,7 @@ def copyObjectColors(ob1,ob2):
     ob2.ViewObject.ShapeColor = ob1.ViewObject.ShapeColor
     ob2.ViewObject.DiffuseColor = newDiffuseColor # set diffuse last
 
-    if not getPerPartTransparency():
+    if not getPerFaceTransparency():
         # touch transparency one to trigger update of 3D View
         # per face transparency probably gets lost
         if ob1.ViewObject.Transparency > 0:

--- a/a2plib.py
+++ b/a2plib.py
@@ -216,33 +216,22 @@ def setTransparency():
         return
 
     shapedObs = filterShapeObs(doc.Objects) # filter out partlist, spreadsheets etc..
-
     sel = FreeCADGui.Selection
+
     for obj in shapedObs:
-        if hasattr(obj,'ViewObject'):
-            if hasattr(obj.ViewObject,'Transparency'):
-                if hasattr(obj.ViewObject,'DiffuseColor'):
-                        SAVED_TRANSPARENCY.append(
-                            (obj.Name, obj.ViewObject.Transparency, obj.ViewObject.DiffuseColor)
-                        )
-                else:
-                    SAVED_TRANSPARENCY.append(
-                        (obj.Name, obj.ViewObject.Transparency, obj.ViewObject.ShapeColor)
-                    )
+        if hasattr(obj,'ViewObject'):                                # save "all-in" *MK
+            if hasattr(obj.ViewObject,'DiffuseColor'):
+                SAVED_TRANSPARENCY.append(
+                    (obj.Name, obj.ViewObject.Transparency, obj.ViewObject.ShapeColor, obj.ViewObject.DiffuseColor)
+                )
             else:
-                if hasattr(obj.ViewObject,'DiffuseColor'):
-                        SAVED_TRANSPARENCY.append(
-                            (obj.Name, obj.ViewObject.DiffuseColor)
-                        )
-                else:
-                    if hasattr(obj.ViewObject,'ShapeColor'):
-                        SAVED_TRANSPARENCY.append(
-                            (obj.Name, obj.ViewObject.ShapeColor)
-                        )
+                SAVED_TRANSPARENCY.append(
+                    (obj.Name, obj.ViewObject.Transparency, obj.ViewObject.ShapeColor, None)
+                )
+
         obj.ViewObject.Transparency = 80
         sel.addSelection(obj) # Transparency workaround. Transparency is taken when once been selected
     sel.clearSelection()
-    
 #------------------------------------------------------------------------------
 def restoreTransparency():
     global SAVED_TRANSPARENCY
@@ -250,23 +239,16 @@ def restoreTransparency():
     doc = FreeCAD.ActiveDocument
 
     sel = FreeCADGui.Selection
-    sel.clearSelection()
+
     for setting in SAVED_TRANSPARENCY:
         obj = doc.getObject(setting[0])
-        if obj is not None:
-            if hasattr(obj.ViewObject,'Transparency'):
-                if not hasattr(obj.ViewObject,'DiffuseColor'):
-                    obj.ViewObject.ShapeColor = setting[2]
-                else:
-                    obj.ViewObject.DiffuseColor = setting[2]
-                obj.ViewObject.Transparency = setting[1]
-            else:
-                if not hasattr(obj.ViewObject,'DiffuseColor'):
-                    obj.ViewObject.ShapeColor = setting[1]
-                else:
-                    obj.ViewObject.DiffuseColor = setting[1]
+        if obj is not None:                                          # restore "all-in" *MK
+            obj.ViewObject.Transparency = setting[1]
+            obj.ViewObject.ShapeColor = setting[2]
+            obj.ViewObject.DiffuseColor = setting[3]                 # diffuse always at last
             sel.addSelection(obj)
-            sel.clearSelection()
+
+    sel.clearSelection()
 
     SAVED_TRANSPARENCY = []
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Hi Klaus,
Two things to fix with this PR:
(1) The fix proposal for toggleTransparency is quite "straight forward", regarding that it collects all relevant data and doesn't bother with checks for data that all A2plus imported files should get imported with (shapeColor, Transparency). But it works well on here and without any delay. Please check the diff.
(2) I still believe, that "source,target" order is appropriate in copyObjectColors, too, so I add my fix for this on here.

Best regards,
Manuel