### PR TITLE
force non native filedialog because of Ubuntu 18.04LTS

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -26,7 +26,7 @@
 __title__ = 'A2plus assembly Workbench - InitGui file'
 __author__ = 'kbwbe'
 
-A2P_VERSION = 'V0.4.17'
+A2P_VERSION = 'V0.4.18'
 
 
 

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -311,8 +311,10 @@ class a2p_ImportPartCommand():
             QtGui.QApplication.activeWindow(),
             "Select FreeCAD document to import part from"
             )
-        #dialog.setNameFilter("Supported Formats (*.FCStd);;STEP files (*.stp *.step);;All files (*.*)")
-        dialog.setNameFilter("Supported Formats (*.FCStd *.stp *.step)") #;;All files (*.*)")
+        # set option "DontUseNativeDialog"=True, as native Filedialog shows
+        # misbehavior on Unbuntu 18.04 LTS. It works case sensitively, what is not wanted...
+        dialog.setOption(QtGui.QFileDialog.DontUseNativeDialog, True)        
+        dialog.setNameFilter("Supported Formats (*.FCStd *.stp *.step);;All files (*.*)")
         if dialog.exec_():
             if PYVERSION < 3:
                 filename = unicode(dialog.selectedFiles()[0])


### PR DESCRIPTION
Ubuntu's 18.04LTS file dialog is working case sensitive. That is not wanted. Therefore now Qt's build in file dialog has been forced.