### PR TITLE
Fixed misc. trivial source comment typos

### DIFF
--- a/a2p_importedPart_class.py
+++ b/a2p_importedPart_class.py
@@ -159,13 +159,13 @@ class ImportedPartViewProviderProxy:
 #==============================================================================
 class Proxy_muxAssemblyObj(Proxy_importPart):
     '''
-    A wrapper for compatibilty reasons...
+    A wrapper for compatibility reasons...
     '''
     pass
 #==============================================================================
 class Proxy_convertPart(Proxy_importPart):
     '''
-    A wrapper for compatibilty reasons...
+    A wrapper for compatibility reasons...
     '''
     pass
 #==============================================================================

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -239,7 +239,7 @@ def importPartFromFile(
                     msg
                     )
                 return
-        else: # use existant shape label
+        else: # use existent shape label
             dc.tx = desiredShapeLabel
             
     #-------------------------------------------


### PR DESCRIPTION
Found using `codespell -q 3 -L vertexes -S ./.git`