### PR TITLE
Fix source comment typos + remove superfluous end of file whitespace

### DIFF
--- a/a2p_MuxAssembly.py
+++ b/a2p_MuxAssembly.py
@@ -64,7 +64,7 @@ def makePlacedShape(obj):
 
 def muxAssemblyWithTopoNames(doc, desiredShapeLabel=None):
     '''
-    Mux an a2p assenbly
+    Mux an a2p assembly
 
     combines all the a2p objects in the doc into one shape
     and populates muxinfo with a description of an edge or face.

--- a/a2p_bom.py
+++ b/a2p_bom.py
@@ -102,7 +102,7 @@ def createPartList(
             for i in range(0,len(PARTLIST_COLUMN_NAMES)):
                 partInformation.append("*")
                 
-            # if there is a proper spreadsheat, then read it...
+            # if there is a proper spreadsheet, then read it...
             for ob in docReader2.getSpreadsheetObjects():
                 
                 sheetName = PARTINFORMATION_SHEET_NAME

--- a/a2p_convertPart.py
+++ b/a2p_convertPart.py
@@ -165,8 +165,8 @@ Please select a Part.
             doc.commitTransaction()
 
     def IsActive(self):
-        """Here you can define if the command must be active or not (greyed) if certain conditions
-        are met or not. This function is optional."""
+        """Here you can define if the command must be active or not (grayed out)
+        if certain conditions are met or not. This function is optional."""
         if FreeCAD.activeDocument() is None:
             return False
         
@@ -174,6 +174,3 @@ Please select a Part.
 
 
 FreeCADGui.addCommand('a2p_ConvertPart',a2p_ConvertPartCommand())
-
-
-

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -1185,7 +1185,7 @@ toolTip = \
 Show only selected elements,
 or all if none is selected.
 
-Select one ore more parts,
+Select one or more parts,
 which are the only ones you
 want to see in a big assembly.
 
@@ -1724,5 +1724,3 @@ def importUpdateConstraintSubobjects( doc, oldObject, newObject ):
                 c = doc.getObject(cName)
                 a2plib.removeConstraint(c)
                 
-
-

--- a/a2plib.py
+++ b/a2plib.py
@@ -794,7 +794,7 @@ def copyObjectColors(ob1,ob2):
             ob1.ViewObject.Transparency = 1
             ob1.ViewObject.Transparency = 0
 
-    # select/unselect object once to trigger update of 3D View
+    # select/deselect object once to trigger update of 3D View
     FreeCADGui.Selection.addSelection(ob1)
     FreeCADGui.Selection.removeSelection(ob1)
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Found using `codespell -q 3 -L dof,vertexes`