### PR TITLE
a2p_constraintDialog.py: uniform angle rounding

### DIFF
--- a/a2p_constraintDialog.py
+++ b/a2p_constraintDialog.py
@@ -188,7 +188,7 @@ class a2p_ConstraintValueWidget(QtGui.QWidget):
             self.roundAngleButton = QtGui.QPushButton(self)
             self.roundAngleButton.setText("Round")
             self.roundAngleButton.setFixedHeight(32)
-            self.roundAngleButton.setToolTip("Round angle to multiples of 90")
+            self.roundAngleButton.setToolTip("Round angle to multiples of 5")
             QtCore.QObject.connect(self.roundAngleButton, QtCore.SIGNAL("clicked()"), self.roundAngle)
             self.mainLayout.addWidget(self.roundAngleButton,self.lineNo,2)
             
@@ -361,24 +361,14 @@ class a2p_ConstraintValueWidget(QtGui.QWidget):
             self.solve()
     
     def roundAngle(self):
-        if self.constraintObject.Type == "axisPlaneAngle":
-            # rounds angle to 1 degrees
-            self.winModified = True
-            q = self.angleEdit.value()
-            q = round(q)
-            q = q
-            self.angleEdit.setValue(q)
-            if a2plib.getAutoSolveState():
-                self.solve()
-        else:
-            # rounds angle to 90 degrees
-            self.winModified = True
-            q = self.angleEdit.value() / 90
-            q = round(q)
-            q = q * 90
-            self.angleEdit.setValue(q)
-            if a2plib.getAutoSolveState():
-                self.solve()
+        # rounds angle to 5 degrees
+        self.winModified = True
+        q = self.angleEdit.value() / 5
+        q = round(q)
+        q = q * 5
+        self.angleEdit.setValue(q)
+        if a2plib.getAutoSolveState():
+            self.solve()
     
     def perpendicularAngle(self):
         if self.constraintObject.Type == "axisPlaneAngle":


### PR DESCRIPTION
as discussed, in practice rounding to 90° is much too rough, 1° is too fine. 5° is a good compromise and this should be used for both angle constraints