### PR TITLE
Setup translation infrastructure for A2+

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -43,7 +43,7 @@ class A2plusWorkbench (Workbench):
         import a2plib
         self.__class__.Icon = a2plib.pathOfModule() + "/icons/a2p_Workbench.svg"
         self.__class__.MenuText = 'A2plus '+A2P_VERSION
-        self.__class__.ToolTip  = 'An other assembly workbench for FreeCAD.'
+        self.__class__.ToolTip  = QT_TRANSLATE_NOOP("A2plus_solversystem", "An other assembly workbench for FreeCAD.")
 
     def Initialize(self):
         import sys

--- a/a2p_MuxAssembly.py
+++ b/a2p_MuxAssembly.py
@@ -168,8 +168,8 @@ class a2p_SimpleAssemblyShapeCommand():
     def GetResources(self):
         import a2plib
         return {'Pixmap'  : a2plib.path_a2p +'/icons/a2p_SimpleAssemblyShape.svg',
-                'MenuText': "Create or refresh simple shape of complete assembly",
-                'ToolTip': toolTip
+                'MenuText': QT_TRANSLATE_NOOP("A2plus_MuxAssembly", "Create or refresh simple shape of complete assembly"),
+                'ToolTip' : toolTip
                 }
 
     def Activated(self):

--- a/a2p_MuxAssembly.py
+++ b/a2p_MuxAssembly.py
@@ -23,14 +23,15 @@
 #***************************************************************************
 
 import FreeCAD, FreeCADGui
-from a2plib import *
+from FreeCAD.Qt import translate
+from PySide import QtGui
 import Part
 import os, copy, numpy
 from random import random, choice
 from FreeCAD import  Base
 import time
 import a2plib
-from PySide import QtGui
+from a2plib import *
 
 from a2p_importedPart_class import Proxy_muxAssemblyObj # for compat
 

--- a/a2p_bom.py
+++ b/a2p_bom.py
@@ -22,6 +22,7 @@
 
 import FreeCADGui,FreeCAD
 from PySide import QtGui, QtCore
+from FreeCAD.Qt import translate
 import Spreadsheet
 import os
 import string

--- a/a2p_bom.py
+++ b/a2p_bom.py
@@ -260,9 +260,9 @@ class a2p_CreatePartlist():
 
     def GetResources(self):
         return {
-            'Pixmap'  :     ':/icons/a2p_PartsList.svg',
-            'MenuText':     'Create a spreadsheet with a parts list of this file',
-            'ToolTip':      toolTip
+            'Pixmap'  : ':/icons/a2p_PartsList.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_CreatePartlist", "Create a spreadsheet with a parts list of this file"),
+            'ToolTip' : toolTip
             }
         
 FreeCADGui.addCommand('a2p_CreatePartlist', a2p_CreatePartlist())

--- a/a2p_constraintDialog.py
+++ b/a2p_constraintDialog.py
@@ -1034,9 +1034,9 @@ class a2p_ConstraintDialogCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : ':/icons/a2p_DefineConstraints.svg',
-             'MenuText': 'Define constraints',
-             'ToolTip': toolTipText
+             'Pixmap'  : ':/icons/a2p_DefineConstraints.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintDialog", "Define constraints"),
+             'ToolTip' : toolTipText
              }
 
 FreeCADGui.addCommand('a2p_ConstraintDialogCommand', a2p_ConstraintDialogCommand())
@@ -1085,9 +1085,9 @@ class a2p_EditConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : ':/icons/a2p_EditConstraint.svg',
-             'MenuText': 'Edit selected constraint',
-             'ToolTip': toolTipText
+             'Pixmap'  : ':/icons/a2p_EditConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintDialog", "Edit selected constraint"),
+             'ToolTip' : toolTipText
              }
 
 FreeCADGui.addCommand('a2p_EditConstraintCommand', a2p_EditConstraintCommand())

--- a/a2p_constraintDialog.py
+++ b/a2p_constraintDialog.py
@@ -27,7 +27,7 @@ from PySide import QtGui, QtCore
 import os, sys, math, copy
 #from a2p_viewProviderProxies import *
 from  FreeCAD import Base
-
+from FreeCAD.Qt import translate
 from a2plib import *
 from a2p_solversystem import solveConstraints
 import a2p_constraints

--- a/a2p_constraintServices.py
+++ b/a2p_constraintServices.py
@@ -25,6 +25,7 @@
 import FreeCAD
 import FreeCADGui
 from PySide import QtGui
+from FreeCAD.Qt import translate
 import a2plib
 import a2p_constraints
 

--- a/a2p_constraintServices.py
+++ b/a2p_constraintServices.py
@@ -101,8 +101,8 @@ class a2p_reAdjustConstraintDirectionsCommand:
     def GetResources(self):
         return {
             'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_ReAdjustConstraints.svg',
-            'MenuText': 'Readjust directions of all constraints',
-            'ToolTip': 'Readjust directions of all constraints to fit best'
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintServices", "Re-adjust directions of all constraints"),
+            'ToolTip' : QT_TRANSLATE_NOOP("A2plus_constraintServices", "Re-adjust directions of all constraints to fit best")
             }
 FreeCADGui.addCommand('a2p_reAdjustConstraintDirectionsCommand', a2p_reAdjustConstraintDirectionsCommand())
 #==============================================================================

--- a/a2p_constraintcommands.py
+++ b/a2p_constraintcommands.py
@@ -77,9 +77,9 @@ class a2p_PointIdentityConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : path_a2p + '/icons/a2p_PointIdentity.svg',
-             'MenuText': 'Add pointIdentity constraint',
-             'ToolTip': a2p_constraints.PointIdentityConstraint.getToolTip()
+             'Pixmap'  : path_a2p + '/icons/a2p_PointIdentity.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add pointIdentity constraint"),
+             'ToolTip' : a2p_constraints.PointIdentityConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_PointIdentityConstraintCommand', a2p_PointIdentityConstraintCommand())
@@ -104,9 +104,9 @@ class a2p_PointOnLineConstraintCommand:
 
     def GetResources(self): 
         return {
-             'Pixmap' : path_a2p + '/icons/a2p_PointOnLineConstraint.svg', 
-             'MenuText': 'Add pointOnLine constraint', 
-             'ToolTip': a2p_constraints.PointOnLineConstraint.getToolTip()
+             'Pixmap'  : path_a2p + '/icons/a2p_PointOnLineConstraint.svg', 
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add pointOnLine constraint"), 
+             'ToolTip' : a2p_constraints.PointOnLineConstraint.getToolTip()
              } 
 
 FreeCADGui.addCommand('a2p_PointOnLineConstraintCommand', a2p_PointOnLineConstraintCommand())
@@ -131,9 +131,9 @@ class a2p_PointOnPlaneConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : path_a2p + '/icons/a2p_PointOnPlaneConstraint.svg',
-             'MenuText': 'Add pointOnPlane constraint',
-             'ToolTip': a2p_constraints.PointOnPlaneConstraint.getToolTip()
+             'Pixmap'  : path_a2p + '/icons/a2p_PointOnPlaneConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add pointOnPlane constraint"),
+             'ToolTip' : a2p_constraints.PointOnPlaneConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_PointOnPlaneConstraintCommand', a2p_PointOnPlaneConstraintCommand())
@@ -158,7 +158,7 @@ class a2p_SphericalSurfaceConstraintCommand:
     def GetResources(self):
         return {
             'Pixmap' : path_a2p + '/icons/a2p_SphericalSurfaceConstraint.svg',
-            'MenuText': 'Add sphereCenterIdent constraint',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add sphereCenterIdent constraint"),
              'ToolTip': a2p_constraints.SphericalConstraint.getToolTip()
             }
 
@@ -183,9 +183,9 @@ class a2p_CircularEdgeConnectionCommand:
 
     def GetResources(self):
         return {
-            'Pixmap' : path_a2p + '/icons/a2p_CircularEdgeConstraint.svg' ,
-            'MenuText': 'Add circularEdge constraint',
-             'ToolTip': a2p_constraints.CircularEdgeConstraint.getToolTip()
+            'Pixmap'  : path_a2p + '/icons/a2p_CircularEdgeConstraint.svg' ,
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add circularEdge constraint"),
+            'ToolTip' : a2p_constraints.CircularEdgeConstraint.getToolTip()
             }
 
 FreeCADGui.addCommand('a2p_CircularEdgeConnection', a2p_CircularEdgeConnectionCommand())
@@ -209,9 +209,9 @@ class a2p_AxialConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : path_a2p + '/icons/a2p_AxialConstraint.svg',
-             'MenuText': 'Add axis Coincident constraint',
-             'ToolTip': a2p_constraints.AxialConstraint.getToolTip()
+             'Pixmap'  : path_a2p + '/icons/a2p_AxialConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add axis Coincident constraint"),
+             'ToolTip' : a2p_constraints.AxialConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_AxialConstraintCommand', a2p_AxialConstraintCommand())
@@ -235,9 +235,9 @@ class a2p_AxisParallelConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : ':/icons/a2p_AxisParallelConstraint.svg',
-             'MenuText': 'Add axisParallel constraint',
-             'ToolTip': a2p_constraints.AxisParallelConstraint.getToolTip()
+             'Pixmap'  : ':/icons/a2p_AxisParallelConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add axisParallel constraint"),
+             'ToolTip' : a2p_constraints.AxisParallelConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_AxisParallelConstraintCommand', a2p_AxisParallelConstraintCommand())
@@ -261,9 +261,9 @@ class a2p_AxisPlaneParallelCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : ':/icons/a2p_AxisPlaneParallelConstraint.svg',
-             'MenuText': 'Add axisPlaneParallel constraint',
-             'ToolTip': a2p_constraints.AxisPlaneParallelConstraint.getToolTip()
+             'Pixmap'  : ':/icons/a2p_AxisPlaneParallelConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add axisPlaneParallel constraint"),
+             'ToolTip' : a2p_constraints.AxisPlaneParallelConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_AxisPlaneParallelCommand', a2p_AxisPlaneParallelCommand())
@@ -287,9 +287,9 @@ class a2p_AxisPlaneAngleCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : ':/icons/a2p_AxisPlaneAngleConstraint.svg',
-             'MenuText': 'Add axisPlaneAngle constraint',
-             'ToolTip': a2p_constraints.AxisPlaneAngleConstraint.getToolTip()
+             'Pixmap'  : ':/icons/a2p_AxisPlaneAngleConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add axisPlaneAngle constraint"),
+             'ToolTip' : a2p_constraints.AxisPlaneAngleConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_AxisPlaneAngleCommand', a2p_AxisPlaneAngleCommand())
@@ -313,9 +313,9 @@ class a2p_AxisPlaneNormalCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : ':/icons/a2p_AxisPlaneNormalConstraint.svg',
-             'MenuText': 'Add axisPlaneNormal constraint',
-             'ToolTip': a2p_constraints.AxisPlaneNormalConstraint.getToolTip()
+             'Pixmap'  : ':/icons/a2p_AxisPlaneNormalConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add axisPlaneNormal constraint"),
+             'ToolTip' : a2p_constraints.AxisPlaneNormalConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_AxisPlaneNormalCommand', a2p_AxisPlaneNormalCommand())
@@ -339,9 +339,9 @@ class a2p_PlanesParallelConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : path_a2p + '/icons/a2p_PlanesParallelConstraint.svg',
-             'MenuText': 'Add planesParallel constraint',
-             'ToolTip': a2p_constraints.PlanesParallelConstraint.getToolTip()
+             'Pixmap'  : path_a2p + '/icons/a2p_PlanesParallelConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add planesParallel constraint"),
+             'ToolTip' : a2p_constraints.PlanesParallelConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_PlanesParallelConstraintCommand', a2p_PlanesParallelConstraintCommand())
@@ -365,9 +365,9 @@ class a2p_PlaneCoincidentConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : path_a2p + '/icons/a2p_PlaneCoincidentConstraint.svg',
-             'MenuText': 'Add planeCoincident constraint',
-             'ToolTip': a2p_constraints.PlaneConstraint.getToolTip()
+             'Pixmap'  : path_a2p + '/icons/a2p_PlaneCoincidentConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add planeCoincident constraint"),
+             'ToolTip' : a2p_constraints.PlaneConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_PlaneCoincidentConstraintCommand', a2p_PlaneCoincidentConstraintCommand())
@@ -392,9 +392,9 @@ class a2p_AngledPlanesConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : path_a2p + '/icons/a2p_AngleConstraint.svg',
-             'MenuText': 'Add angledPlanes constraint',
-             'ToolTip': a2p_constraints.AngledPlanesConstraint.getToolTip()
+             'Pixmap'  : path_a2p + '/icons/a2p_AngleConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add angledPlanes constraint"),
+             'ToolTip' : a2p_constraints.AngledPlanesConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_AngledPlanesConstraintCommand', a2p_AngledPlanesConstraintCommand())
@@ -420,9 +420,9 @@ class a2p_CenterOfMassConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap' : path_a2p + '/icons/a2p_CenterOfMassConstraint.svg',
-             'MenuText': 'Add centerOfMass constraint',
-             'ToolTip': a2p_constraints.CenterOfMassConstraint.getToolTip()
+             'Pixmap'  : path_a2p + '/icons/a2p_CenterOfMassConstraint.svg',
+             'MenuText': QT_TRANSLATE_NOOP("A2plus_constraintcommands", "Add centerOfMass constraint"),
+             'ToolTip' : a2p_constraints.CenterOfMassConstraint.getToolTip()
              }
 
 FreeCADGui.addCommand('a2p_CenterOfMassConstraintCommand', a2p_CenterOfMassConstraintCommand())

--- a/a2p_constraintcommands.py
+++ b/a2p_constraintcommands.py
@@ -26,7 +26,8 @@ import FreeCAD, FreeCADGui, Part
 from PySide import QtGui, QtCore
 import os, sys, math, copy
 from a2p_viewProviderProxies import *
-from  FreeCAD import Base
+from FreeCAD import Base
+from FreeCAD.Qt import translate
 
 from a2plib import *
 from a2p_solversystem import solveConstraints

--- a/a2p_constraints.py
+++ b/a2p_constraints.py
@@ -22,6 +22,7 @@
 #*                                                                         *
 #***************************************************************************
 
+from FreeCAD.Qt import translate
 import FreeCAD
 import  Part
 import a2plib

--- a/a2p_convertPart.py
+++ b/a2p_convertPart.py
@@ -125,8 +125,8 @@ class a2p_ConvertPartCommand():
 
     def GetResources(self):
         return {'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_ConvertPart.svg',
-#                'Accel' : "Shift+C", # a default shortcut (optional)
-                'MenuText': "Convert a part to A2plus",
+#                'Accel'  : "Shift+C", # a default shortcut (optional)
+                'MenuText': QT_TRANSLATE_NOOP("A2plus_convertPart", "Convert a part to A2plus"),
                 'ToolTip' : toolTip
                 }
 

--- a/a2p_convertPart.py
+++ b/a2p_convertPart.py
@@ -25,6 +25,7 @@
 import FreeCADGui
 import FreeCAD
 from PySide import QtGui
+from FreeCAD.Qt import translate
 import copy
 import time
 import a2plib

--- a/a2p_dependencies.py
+++ b/a2p_dependencies.py
@@ -24,6 +24,7 @@ import random
 import math
 import FreeCAD, FreeCADGui, Part
 from  FreeCAD import Base
+from FreeCAD.Qt import translate
 import a2plib
 from a2plib import (
     getObjectEdgeFromName,

--- a/a2p_fcdocumentreader.py
+++ b/a2p_fcdocumentreader.py
@@ -21,6 +21,7 @@
 #***************************************************************************
 
 import FreeCAD, FreeCADGui, os
+from FreeCAD.Qt import translate
 
 import zipfile
 try:

--- a/a2p_filecache.py
+++ b/a2p_filecache.py
@@ -27,6 +27,7 @@ import FreeCADGui
 import Part
 from PySide import QtGui
 from PySide import QtCore
+from FreeCAD.Qt import translate
 import os
 import sys
 import a2plib

--- a/a2p_importedPart_class.py
+++ b/a2p_importedPart_class.py
@@ -30,6 +30,7 @@ import copy
 import numpy
 from FreeCAD import  Base
 from PySide import QtGui
+from FreeCAD.Qt import translate
 import a2plib
 from a2p_versionmanagement import A2P_VERSION
 #==============================================================================

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -25,6 +25,7 @@
 import FreeCADGui
 import FreeCAD
 from PySide import QtGui, QtCore
+from FreeCAD.Qt import translate
 import os
 import copy
 import sys

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -261,8 +261,8 @@ class a2p_Restore_Transparency_Command():
 
     def GetResources(self):
         return {'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_Restore_Transparency.svg',
-                'Accel' : "Shift+T", # a default shortcut (optional)
-                'MenuText': "Restore transparency to active document objects",
+                'Accel'   : "Shift+T", # a default shortcut (optional)
+                'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Restore transparency to active document objects"),
                 'ToolTip' : toolTip
                 }
 
@@ -299,8 +299,8 @@ class a2p_ImportPartCommand():
 
     def GetResources(self):
         return {'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_ImportPart.svg',
-                'Accel' : "Shift+A", # a default shortcut (optional)
-                'MenuText': "Add a part from an external file",
+                'Accel'   : "Shift+A", # a default shortcut (optional)
+                'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Add a part from an external file"),
                 'ToolTip' : toolTip
                 }
 
@@ -553,9 +553,9 @@ class a2p_UpdateImportedPartsCommand:
 
     def GetResources(self):
         return {
-            'Pixmap' : a2plib.path_a2p + '/icons/a2p_ImportPart_Update.svg',
-            'MenuText': 'Update parts imported into the assembly',
-            'ToolTip': toolTip
+            'Pixmap'  : a2plib.path_a2p + '/icons/a2p_ImportPart_Update.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Update parts imported into the assembly"),
+            'ToolTip' : toolTip
             }
 
 FreeCADGui.addCommand('a2p_updateImportedParts', a2p_UpdateImportedPartsCommand())
@@ -655,8 +655,8 @@ class a2p_DuplicatePartCommand:
     def GetResources(self):
         return {
             'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_DuplicatePart.svg',
-            'MenuText': 'Create duplicate of a part',
-            'ToolTip':  toolTip
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Create duplicate of a part"),
+            'ToolTip' : toolTip
             }
 
 FreeCADGui.addCommand('a2p_duplicatePart', a2p_DuplicatePartCommand())
@@ -792,8 +792,8 @@ This is not allowed when using preference
     def GetResources(self):
         return {
             'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_EditPart.svg',
-            'MenuText': 'Edit an imported part (open linked FCStd file)',
-            'ToolTip':  toolTip
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Edit an imported part (open linked FCStd file)"),
+            'ToolTip' : toolTip
             }
 
 FreeCADGui.addCommand('a2p_editImportedPart', a2p_EditPartCommand())
@@ -840,8 +840,8 @@ class a2p_MovePartCommand:
         return {
             #'Pixmap' : ':/assembly2/icons/MovePart.svg',
             'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_MovePart.svg',
-            'MenuText': 'Move the selected part',
-            'ToolTip': toolTip
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Move the selected part"),
+            'ToolTip' : toolTip
             }
 
 FreeCADGui.addCommand('a2p_movePart', a2p_MovePartCommand())
@@ -1000,8 +1000,8 @@ class a2p_MovePartUnderConstraints:
         return {
             #'Pixmap' : ':/assembly2/icons/MovePart.svg',
             'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_MovePartUnderConstraints.svg',
-            'MenuText': 'Move the selected part under constraints',
-            'ToolTip': toolTip
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Move the selected part under constraints"),
+            'ToolTip' : toolTip
             }
 
 FreeCADGui.addCommand('a2p_MovePartUnderConstraints', a2p_MovePartUnderConstraints())
@@ -1079,8 +1079,8 @@ class DeleteConnectionsCommand:
     def GetResources(self):
         return {
             'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_DeleteConnections.svg',
-            'MenuText': 'Delete all constraints of selected parts',
-            'ToolTip': toolTipText
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Delete all constraints of selected parts"),
+            'ToolTip' : toolTipText
             }
 FreeCADGui.addCommand('a2p_DeleteConnectionsCommand', DeleteConnectionsCommand())
 
@@ -1125,9 +1125,9 @@ class ViewConnectionsCommand:
     
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_ViewConnection.svg',
-            'MenuText':     'Highlight both constrained parts',
-            'ToolTip':      toolTip,
+            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_ViewConnection.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Highlight both constrained parts"),
+            'ToolTip' : toolTip
             }
 
 FreeCADGui.addCommand('a2p_ViewConnectionsCommand', ViewConnectionsCommand())
@@ -1220,8 +1220,8 @@ class a2p_isolateCommand:
     def GetResources(self):
         return {
             'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_Isolate_Element.svg',
-            'MenuText': 'Show only selected elements or all if none is selected',
-            'ToolTip': toolTip
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Show only selected elements or all if none is selected"),
+            'ToolTip' : toolTip
             }
 
 FreeCADGui.addCommand('a2p_isolateCommand', a2p_isolateCommand())
@@ -1251,10 +1251,10 @@ class a2p_ToggleTransparencyCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_ToggleTransparency.svg',
-            'MenuText':     'Toggle transparency of assembly',
-            'ToolTip':      'Toggles transparency of assembly',
-            'Checkable':    self.IsChecked()
+            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_ToggleTransparency.svg',
+            'MenuText' : QT_TRANSLATE_NOOP("A2plus_importpart", "Toggle transparency of assembly"),
+            'ToolTip'  : QT_TRANSLATE_NOOP("A2plus_importpart", "Toggles transparency of assembly"),
+            'Checkable': self.IsChecked()
         }
 FreeCADGui.addCommand('a2p_ToggleTransparencyCommand', a2p_ToggleTransparencyCommand())
 
@@ -1284,10 +1284,10 @@ class a2p_ToggleAutoSolveCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_ToggleAutoSolve.svg',
-            'MenuText':     'Toggle auto solve',
-            'ToolTip':      toolTipMessage,
-            'Checkable':    self.IsChecked()
+            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_ToggleAutoSolve.svg',
+            'MenuText' : QT_TRANSLATE_NOOP("A2plus_importpart", "Toggle auto solve"),
+            'ToolTip'  : toolTipMessage,
+            'Checkable': self.IsChecked()
             }
 FreeCADGui.addCommand('a2p_ToggleAutoSolveCommand', a2p_ToggleAutoSolveCommand())
 
@@ -1303,10 +1303,10 @@ class a2p_TogglePartialProcessingCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_TogglePartial.svg',
-            'MenuText':     'Toggle partial processing',
-            'ToolTip':      'Toggles partial processing',
-            'Checkable':    self.IsChecked()
+            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_TogglePartial.svg',
+            'MenuText' : QT_TRANSLATE_NOOP("A2plus_importpart", "Toggle partial processing"),
+            'ToolTip'  : QT_TRANSLATE_NOOP("A2plus_importpart", "Toggle partial processing"),
+            'Checkable': self.IsChecked()
             }
 FreeCADGui.addCommand('a2p_TogglePartialProcessingCommand', a2p_TogglePartialProcessingCommand())
 
@@ -1335,9 +1335,9 @@ class a2p_repairTreeViewCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_RepairTree.svg',
-            'MenuText':     'Repair the tree view if it is somehow damaged',
-            'ToolTip':      toolTipMessage
+            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_RepairTree.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Repair the tree view if it is somehow damaged"),
+            'ToolTip' : toolTipMessage
             }
 FreeCADGui.addCommand('a2p_repairTreeViewCommand', a2p_repairTreeViewCommand())
 
@@ -1366,9 +1366,9 @@ class a2p_FlipConstraintDirectionCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_FlipConstraint.svg',
-            'MenuText':     'Flip direction of last constraint',
-            'ToolTip':      toolTip
+            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_FlipConstraint.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Flip direction of last constraint"),
+            'ToolTip' : toolTip
             }
 FreeCADGui.addCommand('a2p_FlipConstraintDirectionCommand', a2p_FlipConstraintDirectionCommand())
 
@@ -1413,9 +1413,9 @@ class a2p_Show_Hierarchy_Command:
 
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_Treeview.svg',
-            'MenuText':     'Generate HTML file with detailed constraining structure',
-            'ToolTip':      'Generates HTML file with detailed constraining structure'
+            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_Treeview.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Generate HTML file with detailed constraining structure"),
+            'ToolTip' : QT_TRANSLATE_NOOP("A2plus_importpart", "Generates HTML file with detailed constraining structure")
             }
 FreeCADGui.addCommand('a2p_Show_Hierarchy_Command', a2p_Show_Hierarchy_Command())
 
@@ -1479,10 +1479,10 @@ class a2p_Show_PartLabels_Command:
 
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_PartLabel.svg',
-            'MenuText':     "Show part labels in 3D view",
-            'ToolTip':      "Toggle showing part labels in 3D view",
-            'Checkable':    False
+            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_PartLabel.svg',
+            'MenuText' : QT_TRANSLATE_NOOP("A2plus_importpart", "Show part labels in 3D view"),
+            'ToolTip'  : QT_TRANSLATE_NOOP("A2plus_importpart", "Toggle showing part labels in 3D view"),
+            'Checkable': False
             }
 FreeCADGui.addCommand('a2p_Show_PartLabels_Command', a2p_Show_PartLabels_Command())
 
@@ -1513,11 +1513,11 @@ class a2p_Show_DOF_info_Command:
         return dofGroup != None
 
     def GetResources(self):
-        return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_DOFs.svg',
-            'MenuText':     'Print detailed DOF information',
-            'ToolTip':      'Toggle printing detailed DOF information',
-            'Checkable':    False
+        return 
+            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_DOFs.svg',
+            'MenuText' : QT_TRANSLATE_NOOP("A2plus_importpart", "Print detailed DOF information"),
+            'ToolTip'  : QT_TRANSLATE_NOOP("A2plus_importpart", "Toggle printing detailed DOF information"),
+            'Checkable': False
             }
 FreeCADGui.addCommand('a2p_Show_DOF_info_Command', a2p_Show_DOF_info_Command())
 
@@ -1550,9 +1550,9 @@ class a2p_absPath_to_relPath_Command:
             
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_SetRelativePathes.svg',
-            'MenuText':     'Convert absolute paths of imported parts to relative ones',
-            'ToolTip':      'Converts absolute paths of imported parts to relative ones'
+            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_SetRelativePathes.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Convert absolute paths of imported parts to relative ones"),
+            'ToolTip' : QT_TRANSLATE_NOOP("A2plus_importpart", "Converts absolute paths of imported parts to relative ones")
             }
 FreeCADGui.addCommand('a2p_absPath_to_relPath_Command', a2p_absPath_to_relPath_Command())
 
@@ -1581,9 +1581,9 @@ class a2p_SaveAndExit_Command:
             
     def GetResources(self):
         return {
-            'Pixmap'  :     a2plib.pathOfModule()+'/icons/a2p_Save_and_exit.svg',
-            'MenuText':     'Save and exit the active document',
-            'ToolTip':      'Save and exit the active document'
+            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_Save_and_exit.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Save and exit the active document"),
+            'ToolTip' : QT_TRANSLATE_NOOP("A2plus_importpart", "Save and exit the active document")
             }
 FreeCADGui.addCommand('a2p_SaveAndExit_Command', a2p_SaveAndExit_Command())
 
@@ -1600,7 +1600,7 @@ class a2p_ImportShapeReferenceCommand():
     def GetResources(self):
         return {'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_ShapeReference.svg',
                 #'Accel' : "Shift+A", # a default shortcut (optional)
-                'MenuText': "Add a single shape out of an external file",
+                'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Add a single shape out of an external file"),
                 'ToolTip' : toolTip
                 }
 
@@ -1811,9 +1811,9 @@ class a2p_cleanUpDebug3dCommand():
 
     def GetResources(self):
         return {
-            'Pixmap' : ':/icons/a2p_RemoveDebug3D.svg',
-            'MenuText': 'Clean up solver debug output from 3D view',
-            'ToolTip': toolTip
+            'Pixmap'  : ':/icons/a2p_RemoveDebug3D.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_importpart", "Clean up solver debug output from 3D view"),
+            'ToolTip' : toolTip
             }
     
 FreeCADGui.addCommand('a2p_cleanUpDebug3dCommand', a2p_cleanUpDebug3dCommand())

--- a/a2p_lcs_support.py
+++ b/a2p_lcs_support.py
@@ -22,6 +22,7 @@
 
 import FreeCAD
 import FreeCADGui
+from FreeCAD.Qt import translate
 
 
 #==============================================================================

--- a/a2p_libDOF.py
+++ b/a2p_libDOF.py
@@ -25,9 +25,7 @@
 import FreeCAD, FreeCADGui, Part
 from  FreeCAD import Base
 from PySide import QtGui, QtCore
-
-
-
+from FreeCAD.Qt import translate
 
 
 '''

--- a/a2p_migratetoponaming.py
+++ b/a2p_migratetoponaming.py
@@ -22,6 +22,7 @@
 
 import FreeCADGui,FreeCAD
 from PySide import QtGui, QtCore
+from FreeCAD.Qt import translate
 import os
 import string
 

--- a/a2p_migratetoponaming.py
+++ b/a2p_migratetoponaming.py
@@ -114,10 +114,10 @@ class a2p_recursiveToponamingMigrationCommand:
                 pass
         print("=================")
         for f in baseSourceFiles: # this are the basic parts, no one is an assembly
-            print(u"create a2p file for '{}'".format(f))
+            print(translate(u"create a2p file for '{}'".format(f)))
             a2p_filecache.fileCache.loadObject(f) #recent version of part should be in cache now
         print("=================")
-        print("Assemblies to be updated..")
+        print(translate("A2plus", "Assemblies to be updated.."))
         for f in assembliesToUpdate:
             print(f)
         print("=================")
@@ -163,8 +163,8 @@ class a2p_recursiveToponamingMigrationCommand:
     def GetResources(self):
         return {
             #'Pixmap' : ':/icons/a2p_RecursiveUpdate.svg',
-            'MenuText': 'migrate to new toponaming recursively',
-            'ToolTip': toolTip
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_recursiveToponamingMigration", "Migrate to new toponaming recursively"),
+            'ToolTip' : toolTip
             }
 
 FreeCADGui.addCommand('a2p_recursiveToponamingMigrationCommand', a2p_recursiveToponamingMigrationCommand())
@@ -223,9 +223,9 @@ class a2p_MigrateProxiesCommand():
 
     def GetResources(self):
         return {
-            'Pixmap' : ':/icons/a2p_Upgrade.svg',
-            'MenuText': 'Migrate proxies of imported parts',
-            'ToolTip': toolTip
+            'Pixmap'  : ':/icons/a2p_Upgrade.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_recursiveToponamingMigration", "Migrate proxies of imported parts"),
+            'ToolTip' : toolTip
             }
     
 FreeCADGui.addCommand('a2p_MigrateProxiesCommand', a2p_MigrateProxiesCommand())

--- a/a2p_observers.py
+++ b/a2p_observers.py
@@ -23,6 +23,7 @@
 
 import FreeCADGui,FreeCAD
 from PySide import QtGui, QtCore
+from FreeCAD.Qt import translate
 import os, copy, time
 import a2plib
 

--- a/a2p_partinformation.py
+++ b/a2p_partinformation.py
@@ -23,6 +23,7 @@
 import FreeCADGui,FreeCAD
 import Spreadsheet
 from PySide import QtGui, QtCore
+from FreeCAD.Qt import translate
 import os, copy, time, sys, platform
 import a2plib
 from a2p_partlistglobals import PARTLIST_COLUMN_NAMES

--- a/a2p_partinformation.py
+++ b/a2p_partinformation.py
@@ -82,9 +82,9 @@ class a2p_CreatePartInformationSheet_Command:
 
     def GetResources(self):
         return {
-            'Pixmap'  :     ':/icons/a2p_PartsInfo.svg',
-            'MenuText':     'Create a spreadsheet for ordering or logistics information',
-            'ToolTip':      toolTip
+            'Pixmap'  : ':/icons/a2p_PartsInfo.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_partinformation", "Create a spreadsheet for ordering or logistics information"),
+            'ToolTip' : toolTip
             }
         
 FreeCADGui.addCommand('a2p_CreatePartInformationSheet_Command', a2p_CreatePartInformationSheet_Command())

--- a/a2p_recursiveUpdatePlanner.py
+++ b/a2p_recursiveUpdatePlanner.py
@@ -22,6 +22,7 @@
 
 import FreeCADGui,FreeCAD
 from PySide import QtGui
+from FreeCAD.Qt import translate
 import os
 
 import a2plib

--- a/a2p_recursiveUpdatePlanner.py
+++ b/a2p_recursiveUpdatePlanner.py
@@ -204,9 +204,9 @@ class a2p_recursiveUpdateImportedPartsCommand:
 
     def GetResources(self):
         return {
-            'Pixmap' : ':/icons/a2p_RecursiveUpdate.svg',
-            'MenuText': 'update imports recursively',
-            'ToolTip': toolTip
+            'Pixmap'  : ':/icons/a2p_RecursiveUpdate.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_recursiveUpdatePlanner", "Update imports recursively"),
+            'ToolTip' : toolTip
             }
 
 FreeCADGui.addCommand('a2p_recursiveUpdateImportedPartsCommand', a2p_recursiveUpdateImportedPartsCommand())

--- a/a2p_rigid.py
+++ b/a2p_rigid.py
@@ -27,6 +27,7 @@ import math
 import copy
 import FreeCAD, FreeCADGui, Part
 from PySide import QtGui, QtCore
+from FreeCAD.Qt import translate
 from  FreeCAD import Base
 import a2plib
 from a2plib import (

--- a/a2p_searchConstraintConflicts.py
+++ b/a2p_searchConstraintConflicts.py
@@ -106,8 +106,8 @@ Do you want to delete this constraint-pair?
     def GetResources(self):
         return {
             'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_SearchConstraintConflicts.svg',
-            'MenuText': 'Indentify conflicting constraints',
-            'ToolTip': toolTipMessage
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_searchConstraintConflicts", "Indentify conflicting constraints"),
+            'ToolTip' : toolTipMessage
             }
 FreeCADGui.addCommand('a2p_SearchConstraintConflictsCommand', a2p_SearchConstraintConflictsCommand())
 #==============================================================================

--- a/a2p_searchConstraintConflicts.py
+++ b/a2p_searchConstraintConflicts.py
@@ -25,6 +25,7 @@
 import FreeCAD
 import FreeCADGui
 from PySide import QtGui
+from FreeCAD.Qt import translate
 
 import a2plib
 import a2p_solversystem

--- a/a2p_simpleXMLreader.py
+++ b/a2p_simpleXMLreader.py
@@ -34,6 +34,7 @@
 
 import FreeCAD
 import FreeCADGui
+from FreeCAD.Qt import translate
 import os
 import zipfile
 import xml.sax.saxutils as saxutils

--- a/a2p_solversystem.py
+++ b/a2p_solversystem.py
@@ -712,9 +712,9 @@ class a2p_SolverCommand:
 
     def GetResources(self):
         return {
-            'Pixmap' : path_a2p + '/icons/a2p_Solver.svg',
-            'MenuText': 'Solve constraints',
-            'ToolTip': 'Solves constraints'
+            'Pixmap'  : path_a2p + '/icons/a2p_Solver.svg',
+            'MenuText': QT_TRANSLATE_NOOP("A2plus_solversystem", "Solve constraints"),
+            'ToolTip' : QT_TRANSLATE_NOOP("A2plus_solversystem", "Solves constraints")
             }
 
 FreeCADGui.addCommand('a2p_SolverCommand', a2p_SolverCommand())

--- a/a2p_solversystem.py
+++ b/a2p_solversystem.py
@@ -22,6 +22,7 @@
 
 import FreeCAD, FreeCADGui
 from PySide import QtGui
+from FreeCAD.Qt import translate
 import a2plib
 from a2plib import (
     path_a2p,

--- a/a2p_topomapper.py
+++ b/a2p_topomapper.py
@@ -92,6 +92,7 @@ parts are been edited.
 
 
 from PySide import QtGui, QtCore
+from FreeCAD.Qt import translate
 import FreeCAD, FreeCADGui, Part
 from FreeCAD import Base
 import a2plib

--- a/a2plib.py
+++ b/a2plib.py
@@ -28,6 +28,7 @@ from FreeCAD import Base
 import  Part
 from PySide import QtGui
 from PySide import QtCore
+from FreeCAD.Qt import translate
 import os
 import sys
 import copy


### PR DESCRIPTION
Addresses #44  
- [x] Add translations/ directory
- [x] Add import for translation library to *.py files that require it
- [x] Translated all `MenuText`
- [ ] Translated all `tooltips`
- [ ] Translated all relevant `print()` statments
- [ ] Add a2plus to crowdin ([link](https://wiki.freecadweb.org/Translating_an_external_workbench#Send_the_.ts_file_to_a_translation_platform))
- [ ] Automate 

Questions:
* Should we setup similar to how BIM is ?
   `from BimTranslateUtils import *`
    https://github.com/yorikvanhavre/BIM_Workbench/blob/1d257b890c66dc7637e94ae1612dc7cb2a842887/BimBox.py#L29

* How do we translate `print()` statements like `print(u"some text")`
* How do we translate multi-line tooltips?
* How do we test translations?
