### PR TITLE
Add type checking for SubShapeBinder in TopoMapper.isTopLevelInList()

### DIFF
--- a/a2p_topomapper.py
+++ b/a2p_topomapper.py
@@ -396,8 +396,9 @@ class TopoMapper(object):
     def isTopLevelInList(self,lst):
         if len(lst) == 0: return True
         for ob in lst:
+            if ob.isDerivedFrom('PartDesign::SubShapeBinder'): continue
+            if ob.isDerivedFrom('Part::SubShapeBinder'): continue
             if ob.Name.startswith("Group"): continue
-            if ob.Name.startswith("Binder"): continue
             if ob.Name.startswith("ShapeBinder"): continue
             if ob.Name.startswith("Clone"): continue
             if ob.Name.startswith("Part__Mirroring"): continue


### PR DESCRIPTION
Instead of using object name, use type checking to be sure.