### PR TITLE
Fixes close opened document and improve logs by showing the file from…

### DIFF
--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -587,7 +587,8 @@ Check your settings of A2plus preferences.
 
         for io in importedObjectsList:
             if io and a2plib.isA2pSketch(io):
-                io.fixedPosition = True
+                if not any([i.fixedPosition for i in doc.Objects if hasattr(i, 'fixedPosition') ]):
+                    io.fixedPosition = True
 
         for io in importedObjectsList:
             if io and not a2plib.isA2pSketch(io) and not io.fixedPosition:

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -586,11 +586,10 @@ Check your settings of A2plus preferences.
         self.timer.start( 200 ) #0.2 seconds
 
         for io in importedObjectsList:
-            if io  and a2plib.isA2pSketch(io):
+            if io and a2plib.isA2pSketch(io):
                 io.fixedPosition = True
 
-        if len(importedObjectsList) == 1:
-            io = importedObjectsList[0]
+        for io in importedObjectsList:
             if io and not a2plib.isA2pSketch(io) and not io.fixedPosition:
                 PartMover( view, io, deleteOnEscape = True )
 

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -538,8 +538,6 @@ Check your settings of A2plus preferences.
                 )
             return
 
-        print("External opened", ntpath.basename(filename))
-
         #==========================================================================================
         # create a dialog for selection the parts
         #==========================================================================================
@@ -555,6 +553,9 @@ Check your settings of A2plus preferences.
                 )
         dialog.exec_()
 
+        if dialog.rejected:
+            FreeCAD.closeDocument(importDoc.Name)
+
         if dc.tx is None or len(dc.tx)==0:
             return
 
@@ -569,7 +570,10 @@ Check your settings of A2plus preferences.
 
             importedObjectsList.append(importedObject)
 
-        FreeCAD.closeDocument(importDoc.Name)
+        try:
+            FreeCAD.closeDocument(importDoc.Name)
+        except:
+            pass
 
         mw = FreeCADGui.getMainWindow()
         mdi = mw.findChild(QtGui.QMdiArea)


### PR DESCRIPTION
- Fixes the action to close the opened FreeCad file when importing multiples parts.
- `Ctrl+Shift+A` was added to trigger the Import Multiple parts action
- An extra log line was added to show from where the modules are being imported in the log, otherwise, we are going to see a bunch of groups imported modules when importing from multiples places.
- Is also closes the file when the dialog is canceled (rejected)
- It is possible to move objects freely after being imported now