### PR TITLE
Fix _for _bad_icon_path

### DIFF
--- a/CD_checkconstraints.py
+++ b/CD_checkconstraints.py
@@ -97,7 +97,6 @@ class formMain(QtGui.QMainWindow):
         self.btnOpenViewer.move(365, 90)
         self.btnOpenViewer.setFixedWidth(100)
         self.btnOpenViewer.setFixedHeight(28)
-        self.btnOpenViewer.setIcon(QtGui.QIcon('./icons/ConstraintDiagnostics.svg'))
         self.btnOpenViewer.setToolTip("View constraints the assembly.")
         self.btnOpenViewer.setText("Open Viewer")
         self.btnOpenViewer.clicked.connect(lambda:self.openViewer())


### PR DESCRIPTION
Removed line 100 from CD_checkconstraints.py.
Line had bad path which caused an error on startup.