### PR TITLE
Correct classname in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
 
   <content>
     <workbench>
-      <classname>A2plus</classname>
+      <classname>A2plusWorkbench</classname>
       <subdirectory>./</subdirectory>
       <freecadmin>0.16</freecadmin>
     </workbench>


### PR DESCRIPTION
The name of the entry class in `InitGui.py` is `A2plusWorkbench` -- correct the package.xml metadata file to match.