### PR TITLE
Rename and fix "a2p_constraintcommands.py"

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -73,7 +73,7 @@ class A2plusWorkbench (Workbench):
         import a2p_MuxAssembly
         import a2p_partinformation
         import a2p_ConstraintDialog
-        import a2p_constraintcommands
+        import a2p_ConstraintCommands
         import a2p_BoM # BoM == Bill of Materials == partslist
         import a2p_constraintServices
         import a2p_searchConstraintConflicts

--- a/a2p_ConstraintCommands.py
+++ b/a2p_ConstraintCommands.py
@@ -1,26 +1,26 @@
-#***************************************************************************
-#*                                                                         *
-#*   Copyright (c) 2019 kbwbe                                              *
-#*                                                                         *
-#*   Portions of code based on hamish's assembly 2                         *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2019 kbwbe                                              *
+# *                                                                         *
+# *   Portions of code based on hamish's assembly 2                         *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
 
 import os
 import sys
@@ -30,21 +30,22 @@ import copy
 from PySide import QtGui, QtCore
 
 import FreeCAD
+# from FreeCAD import Base
 import FreeCADGui
 import Part
 
-from  FreeCAD import Base
 from a2plib import *
-from a2p_translateUtils import *
+import a2p_constraints
+import a2p_ConstraintDialog
 from a2p_viewProviderProxies import *
 from a2p_solversystem import solveConstraints
-import a2p_constraints, a2p_ConstraintDialog
+
+translate = FreeCAD.Qt.translate
 
 
 class a2p_PointIdentityConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.PointIdentityConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -59,44 +60,44 @@ class a2p_PointIdentityConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : path_a2p + '/icons/a2p_PointIdentity.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add pointIdentity constraint"),
-             'ToolTip' : a2p_constraints.PointIdentityConstraint.getToolTip()
-             }
+            'Pixmap': path_a2p + '/icons/a2p_PointIdentity.svg',
+            'MenuText': translate("A2plus_Constraints", "Add PointIdentity constraint"),
+            'ToolTip': a2p_constraints.PointIdentityConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_PointIdentityConstraintCommand', a2p_PointIdentityConstraintCommand())
 
-#==============================================================================
+
 class a2p_PointOnLineConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.PointOnLineConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
             'createConstraint'
             )
         FreeCADGui.Selection.clearSelection()
-              
+
     def IsActive(self):
         return a2p_constraints.PointOnLineConstraint.isValidSelection(
             FreeCADGui.Selection.getSelectionEx()
             )
 
-    def GetResources(self): 
+    def GetResources(self):
         return {
-             'Pixmap'  : path_a2p + '/icons/a2p_PointOnLineConstraint.svg', 
-             'MenuText': translate("A2plus_constraintcommands", "Add pointOnLine constraint"), 
-             'ToolTip' : a2p_constraints.PointOnLineConstraint.getToolTip()
-             } 
+            'Pixmap': path_a2p + '/icons/a2p_PointOnLineConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add PointOnLine constraint"),
+            'ToolTip': a2p_constraints.PointOnLineConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_PointOnLineConstraintCommand', a2p_PointOnLineConstraintCommand())
 
-#==============================================================================
+
 class a2p_PointOnPlaneConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.PointOnPlaneConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -111,17 +112,18 @@ class a2p_PointOnPlaneConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : path_a2p + '/icons/a2p_PointOnPlaneConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add pointOnPlane constraint"),
-             'ToolTip' : a2p_constraints.PointOnPlaneConstraint.getToolTip()
-             }
+            'Pixmap': path_a2p + '/icons/a2p_PointOnPlaneConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add PointOnPlane constraint"),
+            'ToolTip': a2p_constraints.PointOnPlaneConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_PointOnPlaneConstraintCommand', a2p_PointOnPlaneConstraintCommand())
-#==============================================================================
+
+
 class a2p_SphericalSurfaceConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.SphericalConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -136,17 +138,18 @@ class a2p_SphericalSurfaceConstraintCommand:
 
     def GetResources(self):
         return {
-            'Pixmap' : path_a2p + '/icons/a2p_SphericalSurfaceConstraint.svg',
-            'MenuText': translate("A2plus_constraintcommands", "Add sphereCenterIdent constraint"),
-             'ToolTip': a2p_constraints.SphericalConstraint.getToolTip()
+            'Pixmap': path_a2p + '/icons/a2p_SphericalSurfaceConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add SphereCenterIdent constraint"),
+            'ToolTip': a2p_constraints.SphericalConstraint.getToolTip()
             }
 
+
 FreeCADGui.addCommand('a2p_SphericalSurfaceConstraintCommand', a2p_SphericalSurfaceConstraintCommand())
-#==============================================================================
+
+
 class a2p_CircularEdgeConnectionCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.CircularEdgeConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -161,17 +164,18 @@ class a2p_CircularEdgeConnectionCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  : path_a2p + '/icons/a2p_CircularEdgeConstraint.svg' ,
-            'MenuText': translate("A2plus_constraintcommands", "Add circularEdge constraint"),
-            'ToolTip' : a2p_constraints.CircularEdgeConstraint.getToolTip()
+            'Pixmap': path_a2p + '/icons/a2p_CircularEdgeConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add CircularEdge constraint"),
+            'ToolTip': a2p_constraints.CircularEdgeConstraint.getToolTip()
             }
 
+
 FreeCADGui.addCommand('a2p_CircularEdgeConnection', a2p_CircularEdgeConnectionCommand())
-#==============================================================================
+
+
 class a2p_AxialConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.AxialConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -186,17 +190,18 @@ class a2p_AxialConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : path_a2p + '/icons/a2p_AxialConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add axis Coincident constraint"),
-             'ToolTip' : a2p_constraints.AxialConstraint.getToolTip()
-             }
+            'Pixmap': path_a2p + '/icons/a2p_AxialConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add AxisCoincident constraint"),
+            'ToolTip': a2p_constraints.AxialConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_AxialConstraintCommand', a2p_AxialConstraintCommand())
-#==============================================================================
+
+
 class a2p_AxisParallelConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.AxisParallelConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -211,17 +216,18 @@ class a2p_AxisParallelConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : ':/icons/a2p_AxisParallelConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add axisParallel constraint"),
-             'ToolTip' : a2p_constraints.AxisParallelConstraint.getToolTip()
-             }
+            'Pixmap': ':/icons/a2p_AxisParallelConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add AxisParallel constraint"),
+            'ToolTip': a2p_constraints.AxisParallelConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_AxisParallelConstraintCommand', a2p_AxisParallelConstraintCommand())
-#==============================================================================
+
+
 class a2p_AxisPlaneParallelCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.AxisPlaneParallelConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -236,17 +242,18 @@ class a2p_AxisPlaneParallelCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : ':/icons/a2p_AxisPlaneParallelConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add axisPlaneParallel constraint"),
-             'ToolTip' : a2p_constraints.AxisPlaneParallelConstraint.getToolTip()
+            'Pixmap': ':/icons/a2p_AxisPlaneParallelConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add AxisPlaneParallel constraint"),
+            'ToolTip': a2p_constraints.AxisPlaneParallelConstraint.getToolTip()
              }
 
+
 FreeCADGui.addCommand('a2p_AxisPlaneParallelCommand', a2p_AxisPlaneParallelCommand())
-#==============================================================================
+
+
 class a2p_AxisPlaneAngleCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.AxisPlaneAngleConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -261,17 +268,18 @@ class a2p_AxisPlaneAngleCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : ':/icons/a2p_AxisPlaneAngleConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add axisPlaneAngle constraint"),
-             'ToolTip' : a2p_constraints.AxisPlaneAngleConstraint.getToolTip()
-             }
+            'Pixmap': ':/icons/a2p_AxisPlaneAngleConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add AxisPlaneAngle constraint"),
+            'ToolTip': a2p_constraints.AxisPlaneAngleConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_AxisPlaneAngleCommand', a2p_AxisPlaneAngleCommand())
-#==============================================================================
+
+
 class a2p_AxisPlaneNormalCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.AxisPlaneNormalConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -286,24 +294,25 @@ class a2p_AxisPlaneNormalCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : ':/icons/a2p_AxisPlaneNormalConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add axisPlaneNormal constraint"),
-             'ToolTip' : a2p_constraints.AxisPlaneNormalConstraint.getToolTip()
-             }
+            'Pixmap': ':/icons/a2p_AxisPlaneNormalConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add AxisPlaneNormal constraint"),
+            'ToolTip': a2p_constraints.AxisPlaneNormalConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_AxisPlaneNormalCommand', a2p_AxisPlaneNormalCommand())
-#==============================================================================
+
+
 class a2p_PlanesParallelConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.PlanesParallelConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
             'createConstraint'
             )
         FreeCADGui.Selection.clearSelection()
-        
+
     def IsActive(self):
         return a2p_constraints.PlanesParallelConstraint.isValidSelection(
             FreeCADGui.Selection.getSelectionEx()
@@ -311,17 +320,18 @@ class a2p_PlanesParallelConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : path_a2p + '/icons/a2p_PlanesParallelConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add planesParallel constraint"),
-             'ToolTip' : a2p_constraints.PlanesParallelConstraint.getToolTip()
-             }
+            'Pixmap': path_a2p + '/icons/a2p_PlanesParallelConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add PlanesParallel constraint"),
+            'ToolTip': a2p_constraints.PlanesParallelConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_PlanesParallelConstraintCommand', a2p_PlanesParallelConstraintCommand())
-#==============================================================================
+
+
 class a2p_PlaneCoincidentConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.PlaneConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -336,24 +346,24 @@ class a2p_PlaneCoincidentConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : path_a2p + '/icons/a2p_PlaneCoincidentConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add planeCoincident constraint"),
-             'ToolTip' : a2p_constraints.PlaneConstraint.getToolTip()
-             }
+            'Pixmap': path_a2p + '/icons/a2p_PlaneCoincidentConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add PlaneCoincident constraint"),
+            'ToolTip': a2p_constraints.PlaneConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_PlaneCoincidentConstraintCommand', a2p_PlaneCoincidentConstraintCommand())
-#==============================================================================
+
+
 class a2p_AngledPlanesConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.AngledPlanesConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
             'createConstraint'
             )
         FreeCADGui.Selection.clearSelection()
-
 
     def IsActive(self):
         return a2p_constraints.AngledPlanesConstraint.isValidSelection(
@@ -362,18 +372,18 @@ class a2p_AngledPlanesConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : path_a2p + '/icons/a2p_AngleConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add angledPlanes constraint"),
-             'ToolTip' : a2p_constraints.AngledPlanesConstraint.getToolTip()
-             }
+            'Pixmap': path_a2p + '/icons/a2p_AngleConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add AngledPlanes constraint"),
+            'ToolTip': a2p_constraints.AngledPlanesConstraint.getToolTip()
+            }
+
 
 FreeCADGui.addCommand('a2p_AngledPlanesConstraintCommand', a2p_AngledPlanesConstraintCommand())
 
-#==============================================================================
+
 class a2p_CenterOfMassConstraintCommand:
     def Activated(self):
         selection = FreeCADGui.Selection.getSelectionEx()
-        
         c = a2p_constraints.CenterOfMassConstraint(selection)
         cvp = a2p_ConstraintDialog.a2p_ConstraintValuePanel(
             c.constraintObject,
@@ -388,10 +398,10 @@ class a2p_CenterOfMassConstraintCommand:
 
     def GetResources(self):
         return {
-             'Pixmap'  : path_a2p + '/icons/a2p_CenterOfMassConstraint.svg',
-             'MenuText': translate("A2plus_constraintcommands", "Add centerOfMass constraint"),
-             'ToolTip' : a2p_constraints.CenterOfMassConstraint.getToolTip()
-             }
+            'Pixmap': path_a2p + '/icons/a2p_CenterOfMassConstraint.svg',
+            'MenuText': translate("A2plus_Constraints", "Add CenterOfMass constraint"),
+            'ToolTip': a2p_constraints.CenterOfMassConstraint.getToolTip()
+            }
 
-    
+
 FreeCADGui.addCommand('a2p_CenterOfMassConstraintCommand', a2p_CenterOfMassConstraintCommand())


### PR DESCRIPTION
1. Rename "a2p_ConstraintCommands.py",
2. Small fix - PEP8, translate() context, first letter in MenuText is capital.