### PR TITLE
Change pathOfModule() 

### DIFF
--- a/CD_ConstraintViewer.py
+++ b/CD_ConstraintViewer.py
@@ -244,7 +244,7 @@ class ShowPartProperties(QtGui.QWidget):
         if q.text() == translate("A2plus", "Open Help"):
             # File name may be translated, e.g. to "CD_Помощь для инструмента Диагностики.pdf" (this file must be present)
             pdf_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), translate("A2plus", "CD_Help for Diagnostic tools.pdf"))
-            # pdf_file = a2plib.pathOfModule() + "\CD_Help for Diagnostic tools.pdf"
+            # pdf_file = a2plib.get_module_path() + "\CD_Help for Diagnostic tools.pdf"
             # For Linux Mint 21 64-bit with XFCE
             if sys.platform in ['linux', 'linux2', 'darwin', 'cygwin']:
                 import webbrowser

--- a/InitGui.py
+++ b/InitGui.py
@@ -43,7 +43,7 @@ class A2plusWorkbench (Workbench):
     def __init__(self):
         translate = FreeCAD.Qt.translate
         import a2plib
-        self.__class__.Icon = a2plib.pathOfModule() + "/icons/a2p_Workbench.svg"
+        self.__class__.Icon = a2plib.get_module_path() + "/icons/a2p_Workbench.svg"
         self.__class__.MenuText = 'A2plus'
         self.__class__.ToolTip  = translate("A2plus", "An other assembly workbench for FreeCAD.")
 
@@ -225,7 +225,7 @@ class A2plusWorkbench (Workbench):
            )
 
         FreeCADGui.addPreferencePage(
-            a2plib.pathOfModule() +
+            a2plib.get_module_path() +
             '/GuiA2p/Resources/ui/a2p_prefs.ui','A2plus'
             )
 

--- a/a2p_constraintServices.py
+++ b/a2p_constraintServices.py
@@ -121,7 +121,7 @@ class a2p_reAdjustConstraintDirectionsCommand:
 
     def GetResources(self):
         return {
-            'Pixmap': a2plib.pathOfModule()+'/icons/a2p_ReAdjustConstraints.svg',
+            'Pixmap': a2plib.get_module_path()+'/icons/a2p_ReAdjustConstraints.svg',
             'MenuText': translate("A2plus_Constraints", "Re-adjust directions of all constraints"),
             'ToolTip': translate("A2plus_Constraints", "Re-adjust directions of all constraints to best fit")
             }

--- a/a2p_convertPart.py
+++ b/a2p_convertPart.py
@@ -158,7 +158,7 @@ within this workbench.
 class a2p_ConvertPartCommand():
 
     def GetResources(self):
-        return {'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_ConvertPart.svg',
+        return {'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_ConvertPart.svg',
 #                'Accel'  : "Shift+C", # a default shortcut (optional)
                 'MenuText': translate("A2plus_convertPart", "Convert a part to A2plus"),
                 'ToolTip' : toolTip

--- a/a2p_importedPart_class.py
+++ b/a2p_importedPart_class.py
@@ -145,10 +145,10 @@ class ImportedPartViewProviderProxy:
     def getIcon(self):
         if hasattr(self,"Object"):
             if a2plib.isA2pSketch(self.Object):
-                return a2plib.pathOfModule()+'/icons/a2p_SketchReference.svg'
+                return a2plib.get_module_path()+'/icons/a2p_SketchReference.svg'
             if hasattr(self.Object,"sourceFile") and hasattr(self.Object,"sourcePart"):
                 if self.Object.sourcePart is not None and self.Object.sourcePart !='':
-                    return a2plib.pathOfModule()+'/icons/a2p_ObjReference.svg'
+                    return a2plib.get_module_path()+'/icons/a2p_ObjReference.svg'
             if hasattr(self.Object,"subassemblyImport"):
                 if self.Object.subassemblyImport:
                     return ":/icons/a2p_Asm.svg"

--- a/a2p_importpart.py
+++ b/a2p_importpart.py
@@ -432,7 +432,7 @@ to the assembly
 class a2p_ImportShapeReferenceCommand():
 
     def GetResources(self):
-        return {'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_ShapeReference.svg',
+        return {'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_ShapeReference.svg',
                 'Accel' : "Ctrl+Shift+A", # a default shortcut (optional)
                 'MenuText': translate("A2plus", "Add shapes from an external file"),
                 'ToolTip' : toolTip
@@ -628,7 +628,7 @@ active document objects
 class a2p_Restore_Transparency_Command():
 
     def GetResources(self):
-        return {'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_Restore_Transparency.svg',
+        return {'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_Restore_Transparency.svg',
                 'Accel'   : "Shift+T", # a default shortcut (optional)
                 'MenuText': translate("A2plus", "Restore transparency to active document objects"),
                 'ToolTip' : toolTip
@@ -668,7 +668,7 @@ to the assembly
 class a2p_ImportPartCommand():
 
     def GetResources(self):
-        return {'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_ImportPart.svg',
+        return {'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_ImportPart.svg',
                 'Accel'   : "Shift+A", # a default shortcut (optional)
                 'MenuText': translate("A2plus", "Add a part from an external file"),
                 'ToolTip' : toolTip
@@ -1013,7 +1013,7 @@ class a2p_DuplicatePartCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_DuplicatePart.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_DuplicatePart.svg',
             'MenuText': translate("A2plus", "Create duplicate of a part"),
             'ToolTip' : toolTip
             }
@@ -1140,7 +1140,7 @@ class a2p_EditPartCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_EditPart.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_EditPart.svg',
             'MenuText': translate("A2plus", "Edit an imported part (open linked FCStd file)"),
             'ToolTip' : toolTip
             }
@@ -1230,7 +1230,7 @@ class a2p_MovePartCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_MovePart.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_MovePart.svg',
             'MenuText': translate("A2plus", "Move the selected part"),
             'ToolTip' : toolTip
             }
@@ -1350,7 +1350,7 @@ class a2p_MovePartUnderConstraints:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_MovePartUnderConstraints.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_MovePartUnderConstraints.svg',
             'MenuText': translate("A2plus", "Move the selected part under constraints"),
             'ToolTip' : toolTip
             }
@@ -1431,7 +1431,7 @@ class DeleteConnectionsCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_DeleteConnections.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_DeleteConnections.svg',
             'MenuText': translate("A2plus", "Delete all constraints of selected parts"),
             'ToolTip' : toolTipText
             }
@@ -1482,7 +1482,7 @@ class ViewConnectionsCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_ViewConnection.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_ViewConnection.svg',
             'MenuText': translate("A2plus", "Highlight both constrained parts"),
             'ToolTip' : toolTip
             }
@@ -1580,7 +1580,7 @@ class a2p_isolateCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_Isolate_Element.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_Isolate_Element.svg',
             'MenuText': translate("A2plus", "Show only selected elements or all if none is selected"),
             'ToolTip' : toolTip
             }
@@ -1610,7 +1610,7 @@ class a2p_ToggleTransparencyCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_ToggleTransparency.svg',
+            'Pixmap'   : a2plib.get_module_path()+'/icons/a2p_ToggleTransparency.svg',
             'MenuText' : translate("A2plus", "Toggle transparency of assembly"),
             'ToolTip'  : translate("A2plus", "Toggles transparency of assembly"),
             'Checkable': self.IsChecked()
@@ -1644,7 +1644,7 @@ class a2p_ToggleAutoSolveCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_ToggleAutoSolve.svg',
+            'Pixmap'   : a2plib.get_module_path()+'/icons/a2p_ToggleAutoSolve.svg',
             'MenuText' : translate("A2plus", "Toggle auto solve"),
             'ToolTip'  : toolTipMessage,
             'Checkable': self.IsChecked()
@@ -1663,7 +1663,7 @@ class a2p_TogglePartialProcessingCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_TogglePartial.svg',
+            'Pixmap'   : a2plib.get_module_path()+'/icons/a2p_TogglePartial.svg',
             'MenuText' : translate("A2plus", "Toggle partial processing"),
             'ToolTip'  : translate("A2plus", "Toggle partial processing"),
             'Checkable': self.IsChecked()
@@ -1688,7 +1688,7 @@ class a2p_repairTreeViewCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_RepairTree.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_RepairTree.svg',
             'MenuText': translate("A2plus", "Repair the tree view if it is somehow damaged"),
             'ToolTip' : toolTipMessage
             }
@@ -1723,7 +1723,7 @@ class a2p_FlipConstraintDirectionCommand:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_FlipConstraint.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_FlipConstraint.svg',
             'MenuText': translate("A2plus", "Flip direction of last constraint"),
             'ToolTip' : toolTip
             }
@@ -1772,7 +1772,7 @@ class a2p_Show_Hierarchy_Command:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_Treeview.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_Treeview.svg',
             'MenuText': translate("A2plus", "Generate HTML file with detailed constraining structure"),
             'ToolTip' : translate("A2plus", "Generates HTML file with detailed constraining structure")
             }
@@ -1838,7 +1838,7 @@ class a2p_Show_PartLabels_Command:
 
     def GetResources(self):
         return {
-            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_PartLabel.svg',
+            'Pixmap'   : a2plib.get_module_path()+'/icons/a2p_PartLabel.svg',
             'MenuText' : translate("A2plus", "Show part labels in 3D view"),
             'ToolTip'  : translate("A2plus", "Toggle showing part labels in 3D view"),
             'Checkable': False
@@ -1874,7 +1874,7 @@ class a2p_Show_DOF_info_Command:
 
     def GetResources(self):
         return {
-            'Pixmap'   : a2plib.pathOfModule()+'/icons/a2p_DOFs.svg',
+            'Pixmap'   : a2plib.get_module_path()+'/icons/a2p_DOFs.svg',
             'MenuText' : translate("A2plus", "Print detailed DOF information"),
             'ToolTip'  : translate("A2plus", "Toggle printing detailed DOF information"),
             'Checkable': False
@@ -1910,7 +1910,7 @@ class a2p_absPath_to_relPath_Command:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_SetRelativePathes.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_SetRelativePathes.svg',
             'MenuText': translate("A2plus", "Convert absolute paths of imported parts to relative ones"),
             'ToolTip' : translate("A2plus", "Converts absolute paths of imported parts to relative ones")
             }
@@ -1940,7 +1940,7 @@ class a2p_SaveAndExit_Command:
 
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_Save_and_exit.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_Save_and_exit.svg',
             'MenuText': translate("A2plus", "Save and exit the active document"),
             'ToolTip' : translate("A2plus", "Save and exit the active document")
             }

--- a/a2p_searchConstraintConflicts.py
+++ b/a2p_searchConstraintConflicts.py
@@ -109,7 +109,7 @@ Do you want to delete this constraint-pair?
                     
     def GetResources(self):
         return {
-            'Pixmap'  : a2plib.pathOfModule()+'/icons/a2p_SearchConstraintConflicts.svg',
+            'Pixmap'  : a2plib.get_module_path()+'/icons/a2p_SearchConstraintConflicts.svg',
             'MenuText': translate("A2plus_searchConstraintConflicts", "Identify conflicting constraints"),
             'ToolTip' : toolTipMessage
             }

--- a/a2plib.py
+++ b/a2plib.py
@@ -135,15 +135,59 @@ elif "LINUX" in tmp:
 else:
     OPERATING_SYSTEM = "OTHER"
 
+#------------------------------------------------------------------------------
+def get_module_path():
+    """
+    Function return A2p module path. It tested in FreeCAD 0.19 and 0.21 in Linux 64-bit:
+    
+    Not work in both FreeCAd versions (return different end of string in different FreeCAD versions):
+    print("os.path.dirname(): " + os.path.dirname(__file__))
+    
+    Work in both FreeCAd versions:
+    print("os.path.abspath(): " + os.path.abspath(__file__))
+    print("os.path.dirname(os.path.abspath(__file__)): " + os.path.dirname(os.path.abspath(__file__)))
+
+    # FreeCAD 0.19:
+    # os.path.dirname(): /home/user/.FreeCAD/Mod/A2plus
+
+    # os.path.abspath(): /home/user/.FreeCAD/Mod/A2plus/a2plib.py
+    # os.path.dirname(os.path.abspath(__file__)): /home/user/.FreeCAD/Mod/A2plus
+
+    # FreeCAD 0.21:
+    # os.path.dirname(): /home/user/.local/share/FreeCAD/Mod/A2plus/.
+
+    # os.path.abspath(): /home/user/.local/share/FreeCAD/Mod/A2plus/a2plib.py
+    # os.path.dirname(os.path.abspath(__file__)): /home/user/.local/share/FreeCAD/Mod/A2plus
+    """
+
+    s_path = os.path.dirname(os.path.abspath(__file__))
+    return s_path
 
 #------------------------------------------------------------------------------
 def getLanguagePath():
-    return os.path.join(os.path.dirname(os.path.dirname(__file__)),"translations")
+    """
+    Function return path for localization files. It tested in FreeCAD 0.19 and 0.21 in Linux 64-bit:
+
+    Work in both FreeCAd versions:
+    print("os.path.join(get_module_path(), 'translations'): " + os.path.join(get_module_path(), "translations"))
+
+    # FreeCAD 0.19:
+    # os.path.join(get_module_path(), 'translations'): /home/user/.FreeCAD/Mod/A2plus/translations
+
+    # FreeCAD 0.21:
+    # os.path.join(get_module_path(), 'translations'): /home/user/.local/share/FreeCAD/Mod/A2plus/translations
+    """
+
+    s_path = os.path.join(get_module_path(), "translations")
+    return s_path
 
 #------------------------------------------------------------------------------
 def getA2pVersion():
-    #A2plus_path = os.path.dirname(pathOfModule())
-    A2plus_path = pathOfModule()
+    """
+    Function return A2Plus version for storing in assembly file
+    """
+
+    A2plus_path = get_module_path()
     try:
         metadata = FreeCAD.Metadata(os.path.join(A2plus_path, 'package.xml'))
         return metadata.Version
@@ -586,10 +630,6 @@ def checkFileIsInProjectFolder(path):
         return True
     else:
         return False
-
-#------------------------------------------------------------------------------
-def pathOfModule():
-    return os.path.dirname(__file__)
 
 #------------------------------------------------------------------------------
 def Msg(tx):


### PR DESCRIPTION
pathOfModule() not work in FreeCAD 0.19 and 0.21 both.
What I did:
1. Change pathOfModule() for work in both FreeCAD versions,
2. Change getLanguagePath(),
3. Rename pathOfModule() to get_module_path() in all .py files.

I test it in Linux 64-bit.
I test it in Windows 10 64-bit too.