### PR TITLE
[A2P] Python 3.11.x and above Json Fix for FreeCAD 0.21.2 and above

### DIFF
--- a/a2p_MuxAssembly.py
+++ b/a2p_MuxAssembly.py
@@ -217,6 +217,12 @@ class ViewProviderSimpleAssemblyShape:
     def __setstate__(self, state):
         return None
 
+    def dumps(self):
+        return None
+
+    def loads(self, state):
+        return None
+
     def getIcon(self):
         return a2plib.path_a2p + '/icons/SimpleAssemblyShape.svg'
 

--- a/a2p_importedPart_class.py
+++ b/a2p_importedPart_class.py
@@ -82,7 +82,13 @@ class Proxy_importPart:
     def __getstate__(self):
         return None
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
+        return None
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
         return None
 
     def execute(self, obj):
@@ -161,6 +167,12 @@ class ImportedPartViewProviderProxy:
         return None
 
     def __setstate__(self, state):
+        return None
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
         return None
 
     def attach(self, vobj):

--- a/a2p_lcs_support.py
+++ b/a2p_lcs_support.py
@@ -88,7 +88,13 @@ class VP_LCS_Group(object):
     def __getstate__(self):
         return None
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
+        return None
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
         return None
 
 #==============================================================================

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>A2plus</name>
   <description>Another assembly workbench for FreeCAD, following and extending Hamish's Assembly 2 workbench hence Assembly2plus. The main goal of A2plus is to create a very simple, easy to use, and not over-featured workbench for FreeCAD assemblies. Using the KISS principle: KEEP IT SIMPLE, STUPID</description>
-  <version>0.4.61</version>
+  <version>0.4.62</version>
   <date>2022-01-24</date>
   <maintainer email="kbwbe@gmx.de">kbwbe</maintainer>
   <license file="LICENSE">LGPLv2.1</license>


### PR DESCRIPTION
In order to fix errors using Python 3.11.x and above while preserving ability for Python 3.10.x and below to still work correctly, example error from another workbench:

```
  File "/usr/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
<class 'TypeError'>: Object of type FeaturePython is not JSON serializable
17:04:02  PropertyPythonObject::toString(): failed for <class 'SheetMetalCmd.SMViewProviderFlat'>
17:04:02  pyException: Traceback (most recent call last):
  File "/usr/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
```

Root Cause is https://github.com/FreeCAD/FreeCAD/commit/fbe2fef

Fixes https://github.com/kbwbe/A2plus/issues/613