### PR TITLE
fix #658 Fail to import FCStd containing assembly workbench

### DIFF
--- a/a2plib.py
+++ b/a2plib.py
@@ -377,6 +377,15 @@ def filterShapeObs(_list, allowSketches=False):
             if ob.Name.startswith("Sketch"):
                 lst.append(ob)
                 continue
+        # Exclude any objects from assembly workbench, as they are not real shapes and cause problems with the solver.
+        # This includes built-in Assembly objects and their children, including Body, Boolean
+        if ob.TypeId.startswith("Assembly::"):
+            #filter out the built-in Assembly objects
+            continue
+        if ob.Parents and any( p[0].TypeId.startswith("Assembly::") for p in ob.Parents):
+            #filter out objects which are children of built-in Assembly objects
+            continue
+
         if (
             #Following object now have App::GeoFeatureGroupExtension in FC0.19
             #prevent them from being filtered out.


### PR DESCRIPTION
A FCStd file may contain the assembly workbench which A2Plus fails to import. 
This PR adds the exclusion rules in `a2plib.filterShapeObs` to filter assembly objects.

## Detail
The testing FCStd file could be found here: [Test_exclude_assembly.FCStd.txt](https://github.com/user-attachments/files/26376390/Test_exclude_assembly.FCStd.txt)
It contains a cube and an assembly, shown below.
<img width="1910" height="1123" alt="image" src="https://github.com/user-attachments/assets/e2aa3dcf-3684-4ec9-83fd-01c0cbba0823" />

### Step to reproduce an error
- A2Plus > Add a part from external file (a2p_ImportPart)
- Select Test_exclude_assembly.FCStd
- The report panel will show the error:
```sh
Running the Python command 'a2p_ImportPart' failed:
Traceback (most recent call last):
  File "C:\Users\User\AppData\Roaming\FreeCAD\v1-1\Mod\A2plus\.\a2p_importpart.py", line 725, in Activated
    importedObject = importPartFromFile(doc, filename)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\User\AppData\Roaming\FreeCAD\v1-1\Mod\A2plus\.\a2p_importpart.py", line 372, in importPartFromFile
    topoMapper.createTopoNames()
  File "C:\Users\User\AppData\Roaming\FreeCAD\v1-1\Mod\A2plus\.\a2p_topomapper.py", line 640, in createTopoNames
    shapeCol = ob.Color
               ^^^^^^^^

'App.DocumentObject' object has no attribute 'Color'
```

## Workaround
1. My idea to fix this issue is using `TypeId` to filter out the assembly objects `Assembly::AssemblyObject`. 
2. Checking the `TypeId == Assembly::*` does not filter the `Body002` and `Body003` (which are `App::Link` in Assembly). We also need to check the parents of the objects. If any of them is Assembly, the object will be excluded.

Any feedback or comment is welcomed. 


